### PR TITLE
✨ feat: 로그인, 회원가입 tanstack query + API 구현 

### DIFF
--- a/src/api/member/getConfirmAuth.ts
+++ b/src/api/member/getConfirmAuth.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { END_POINTS } from '@/constants/api';
+import { AuthenticationUser } from '@/types/ResponseType';
+
+export const getConfirmAuth = async () => {
+  const { data } = await axios.post<AuthenticationUser>('/api/auth', {
+    method: 'GET',
+    url: END_POINTS.AUTH_USER
+  });
+  return data;
+};

--- a/src/api/member/postSignIn.ts
+++ b/src/api/member/postSignIn.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { END_POINTS } from '@/constants/api';
+import { Authentication } from '@/types/ResponseType';
+
+export const postSignIn = async (signInData: object) => {
+  const { data } = await axios.post<Authentication>('/api', {
+    method: 'POST',
+    url: END_POINTS.SIGNIN,
+    data: signInData
+  });
+  return data;
+};

--- a/src/api/member/postSignUp.ts
+++ b/src/api/member/postSignUp.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { END_POINTS } from '@/constants/api';
+import { Authentication } from '@/types/ResponseType';
+
+export const postSignUp = async (signUpData: object) => {
+  const { data } = await axios.post<Authentication>('/api', {
+    method: 'POST',
+    url: END_POINTS.SIGNUP,
+    data: signUpData
+  });
+  return data;
+};

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,7 @@
+export const END_POINTS = {
+  SIGNIN: '/login',
+  SIGNUP: '/signup',
+  AUTH_USER: '/auth-user'
+};
+
+export const ACCESS_TOKEN_KEY = 'ACCESS_TOKEN';

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,5 @@
+export const PATH = {
+  ROOT: '/',
+  SIGNIN: '/signin',
+  SIGNUP: '/signup'
+};

--- a/src/hooks/api/useConfirmAuthQuery.ts
+++ b/src/hooks/api/useConfirmAuthQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { getConfirmAuth } from '@/api/member/getConfirmAuth';
+
+export const useConfirmAuthQuery = () => {
+  return useQuery({
+    queryKey: ['confirmAuth'],
+    queryFn: getConfirmAuth
+  });
+};

--- a/src/hooks/api/useSignInMutation.ts
+++ b/src/hooks/api/useSignInMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { postSignIn } from '@/api/member/postSignIn';
+import { isLoggedInAtom, tokenAtom } from '@/store/auth';
+
+export const useSignInMutation = () => {
+  const setTokenState = useSetAtom(tokenAtom);
+  const setIsLoggedIn = useSetAtom(isLoggedInAtom);
+
+  const signInMutation = useMutation({
+    mutationFn: postSignIn,
+    onSuccess: ({ token }) => {
+      setTokenState(token);
+      setIsLoggedIn(true);
+    },
+    onError: () => {
+      setIsLoggedIn(false);
+    }
+  });
+
+  return { mutateSignIn: signInMutation.mutate };
+};

--- a/src/hooks/api/useSignUpMutation.ts
+++ b/src/hooks/api/useSignUpMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { postSignUp } from '@/api/member/postSignUp';
+import { isLoggedInAtom, tokenAtom } from '@/store/auth';
+
+export const useSignUpMutation = () => {
+  const setTokenState = useSetAtom(tokenAtom);
+  const setIsLoggedIn = useSetAtom(isLoggedInAtom);
+
+  const signUpMutation = useMutation({
+    mutationFn: postSignUp,
+    onSuccess: ({ token }) => {
+      setTokenState(token);
+      setIsLoggedIn(true);
+    },
+    onError: () => {
+      setIsLoggedIn(false);
+    }
+  });
+
+  return { mutateSignUp: signUpMutation.mutate };
+};

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,6 @@
+import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+import { ACCESS_TOKEN_KEY } from '@/constants/api';
+
+export const isLoggedInAtom = atom(false);
+export const tokenAtom = atomWithStorage(ACCESS_TOKEN_KEY, '');

--- a/src/types/ResponseType.tsx
+++ b/src/types/ResponseType.tsx
@@ -116,3 +116,29 @@ export interface Message {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface Authentication {
+  user: AuthenticationUser;
+  token: string;
+}
+
+export interface AuthenticationUser {
+  role: string;
+  emailVerified: boolean;
+  banned: boolean;
+  isOnline: boolean;
+  posts: [];
+  likes: [];
+  comments: [];
+  followers: [];
+  following: [];
+  notifications: [];
+  messages: [];
+  _id: string;
+  fullName: string;
+  email: string;
+  password: string;
+  createdAt: string;
+  updatedAt: string;
+  __v: 0;
+}


### PR DESCRIPTION
## **📌** 작업 내용
로그인, 회원가입 tanstackquery를 이용한 API 구현

1. 로그인, 회원가입 한 후 token을 localstorage에 저장
    - jotai에서 제공하는 atomWithStorage 사용
2. jotai store에 isLoggedInAtom을 생성하고, token이 있으면 해당 값을 true로 변경
3. 로그인, 회원가입 ResponseType 추가

## 🚦 특이 사항

아직 로그인, 회원가입 form과 연동하지 않았고, 잘 작동하는 것만 테스트했습니다!! 

테스트하면서 UI관련 수정해야하는 내용이 있어 다음 PR 떄 올리겠습니다!

1. tanstack query + api ui와 연결
2. 회원가입 API 명세서에 맞게 value 수정
3. 비밀번호 확인 input 삭제

[파일구조]
```markdown
├─ src
│  ├─ api
│  │  └─ member
│  │     ├─ getConfirmAuth.ts
│  │     ├─ postSignIn.ts
│  │     └─ postSignUp.ts
│  ├─ constants
│  │  ├─ api.ts   // api 경로
│  │  └─ path.ts  // 라우팅 경로
│  ├─ hooks
│  │  ├─ api
│  │  │  ├─ useConfirmAuthQuery.ts
│  │  │  ├─ useSignInMutation.ts
│  │  │  └─ useSignUpMutation.ts
│  ├─ store
│  │  └─ auth.ts
```