### PR TITLE
🔨 refactor: 권한별 페이지 라우팅 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,8 @@
 import { Toaster } from 'react-hot-toast';
-
-
 import { Route, Routes } from 'react-router-dom';
-import Button from './components/Common/Button';
-import SignIn from './components/Common/SignIn';
-import useModal from './hooks/useModal';
-import { authRoutes, userRoutes } from './route/AppRouter';
+import SignIn from '@components/Common/SignIn';
+import { authRoutes, commonRoutes, userRoutes } from './route/AppRouter';
 import AuthMiddleware from './route/AuthMiddleware';
-import { theme } from './theme';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import Post from '@components/Post';
-import Comment from '@components/PostComment';
-import PasswordUpdate from './components/Mypage/PasswordUpdate';
-import ProfileUpdate from './components/Mypage/ProfileUpdate';
-import CommentListPage from './pages/CommentListPage';
-import FollowPage from './pages/FollowPage';
-import LikeListPage from './pages/LikeListPage';
-import Mypage from './pages/Mypage';
-import PostListPage from './pages/PostListPage';
 
 function App() {
   const toastStyle = {
@@ -28,46 +13,26 @@ function App() {
 
   return (
     <>
-      <BrowserRouter>
-        <Routes>
+      <Routes>
+        {authRoutes.map((route, idx) => (
           <Route
-            path="/post"
-            element={<Post />}
-          />
+            path={route.path}
+            element={<SignIn>{route.component}</SignIn>}
+            key={idx}></Route>
+        ))}
+        {userRoutes.map((route, idx) => (
           <Route
-            path="/comment"
-            element={<Comment />}
-          />
+            path={route.path}
+            element={<AuthMiddleware>{route.component}</AuthMiddleware>}
+            key={idx}></Route>
+        ))}
+        {commonRoutes.map((route, idx) => (
           <Route
-            path="/mypage"
-            element={<Mypage />}>
-            <Route
-              path="/mypage/profile-update"
-              element={<ProfileUpdate />}
-            />
-            <Route
-              path="/mypage/follow"
-              element={<FollowPage />}
-            />
-            <Route
-              path="/mypage/post-list"
-              element={<PostListPage />}
-            />
-            <Route
-              path="/mypage/like-list"
-              element={<LikeListPage />}
-            />
-            <Route
-              path="/mypage/comment-list"
-              element={<CommentListPage />}
-            />
-            <Route
-              path="/mypage/password-update"
-              element={<PasswordUpdate />}
-            />
-          </Route>
-        </Routes>
-      </BrowserRouter>
+            path={route.path}
+            element={<>{route.component}</>}
+            key={idx}></Route>
+        ))}
+      </Routes>
 
       <Toaster
         toastOptions={{

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,5 +1,14 @@
 export const PATH = {
   ROOT: '/',
   SIGNIN: '/signin',
-  SIGNUP: '/signup'
+  SIGNUP: '/signup',
+  MYPAGE: '/mypage',
+  MYPAGE_PROFILE_UPDATE: '/mypage/profile-update',
+  MYPAGE_FOLLOW: '/mypage/follow',
+  MYPGE_POST_LIST: '/mypage/post-list',
+  MYPGE_LIKE_LIST: '/mypage/like-list',
+  MYPGE_COMMNET_LIST: '/mypage/comment-list',
+  MYPGE_PASSWORD_LIST: '/mypage/password-list',
+  POST: '/post',
+  COMMENT: '/comment'
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { Global, ThemeProvider } from '@emotion/react';
 import reset from './styles/_reset';
 import global from './styles/global';
 import { theme } from './theme';
+import { BrowserRouter } from 'react-router-dom';
 
 const queryClient = new QueryClient();
 
@@ -15,9 +16,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <ReactQueryDevtools initialIsOpen={true} />
     <ThemeProvider theme={theme}>
       <Global styles={[reset, global]} />
+      <BrowserRouter>
       <React.StrictMode>
         <App />
       </React.StrictMode>
+      </BrowserRouter>
     </ThemeProvider>
   </QueryClientProvider>
 );

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -1,4 +1,4 @@
-import SignUpForm from '@/components/Account/SingUpForm';
+import SignUpForm from "@/components/Account/SignUpForm";
 
 function SignUpPage() {
   return (

--- a/src/route/AppRouter.tsx
+++ b/src/route/AppRouter.tsx
@@ -1,24 +1,44 @@
 import { ReactElement } from 'react';
-import { Navigate } from 'react-router-dom';
+import PasswordUpdate from '@/components/Mypage/PasswordUpdate';
+import ProfileUpdate from '@/components/Mypage/ProfileUpdate';
+import Post from '@/components/Post';
+import Comment from '@/components/PostComment';
+import CommentListPage from '@/pages/CommentListPage';
+import FollowPage from '@/pages/FollowPage';
+import LikeListPage from '@/pages/LikeListPage';
+import Mypage from '@/pages/Mypage';
+import PostListPage from '@/pages/PostListPage';
 import SignInPage from '@/pages/SignInPage';
 import SignUpPage from '@/pages/SignUpPage';
+import { PATH } from '@/constants/path';
 
 interface RouteProps {
   path: string;
   component: ReactElement;
-  exact?: boolean;
+  exact: boolean;
 }
 
 // 로그인 상태 접근
 const userRoutes: Array<RouteProps> = [
-  { path: '/mypage', exact: true, component: <Navigate to="/mypage" /> }
+  { path: PATH.MYPAGE, exact: true, component: <Mypage /> },
+  { path: PATH.MYPAGE_PROFILE_UPDATE, exact: true, component: <ProfileUpdate /> },
+  { path: PATH.MYPAGE_FOLLOW, exact: true, component: <FollowPage /> },
+  { path: PATH.MYPGE_POST_LIST, exact: true, component: <PostListPage /> },
+  { path: PATH.MYPGE_LIKE_LIST, exact: true, component: <LikeListPage /> },
+  { path: PATH.MYPGE_COMMNET_LIST, exact: true, component: <CommentListPage /> },
+  { path: PATH.MYPGE_PASSWORD_LIST, exact: true, component: <PasswordUpdate /> }
 ];
 
 // 로그인 상태x 접근
 const authRoutes: Array<RouteProps> = [
-  { path: '/', exact: true, component: <Navigate to="/" /> },
-  { path: '/signin', component: <SignInPage /> },
-  { path: '/signup', component: <SignUpPage /> }
+  { path: PATH.SIGNIN, exact: true, component: <SignInPage /> },
+  { path: PATH.SIGNUP, exact: true, component: <SignUpPage /> }
 ];
 
-export { userRoutes, authRoutes };
+// 모든 상태에서 접근 가능
+const commonRoutes: Array<RouteProps> = [
+  { path: PATH.POST, exact: true, component: <Post /> },
+  { path: PATH.COMMENT, exact: true, component: <Comment /> }
+];
+
+export { userRoutes, authRoutes, commonRoutes };

--- a/src/route/AuthMiddleware.tsx
+++ b/src/route/AuthMiddleware.tsx
@@ -1,15 +1,16 @@
 import { ReactElement } from 'react';
 import { Navigate } from 'react-router-dom';
-import { useAtomValue } from 'jotai';
-import { tokenAtom } from '@/store/auth';
 import { PATH } from '../constants/path';
+import { ACCESS_TOKEN_KEY } from '@/constants/api';
+import { getStorage } from '@/utils/LocalStorage';
 
 interface AuthMiddlewareProps {
   children: ReactElement;
 }
 const AuthMiddleware = ({ children }: AuthMiddlewareProps) => {
-  const storage = useAtomValue(tokenAtom);
-  if (!storage) {
+  const token = getStorage(ACCESS_TOKEN_KEY);
+
+  if (!token) {
     return <Navigate to={PATH.SIGNIN} />;
   }
   return children;


### PR DESCRIPTION
## **📌** 작업 내용
- 기존 App.tsx에 있던 Route 권한별 페이지에 접근할 수 있도록 라우팅 수정

    **`AppRoutes.tsx`**
    - `userRoutes`: 로그인 상태에서 접근 가능한 페이지
    - `authRoutes`: 로그인하지않은 상태에서 접근 가능한 페이지
    - `commonRoutes`: 모든 상태에서 접근 가능한 페이지

- `App.tsx` 중복되는 import 삭제

## 🚦 특이 사항

공유했던 것 처럼 `AuthMiddleware`에서 token이 출력되지않아 임시로 getStorage로 token을 받아오고있습니다! 
jotai `atomWithStorage`를 이용하는 것과 `getStorage` 중 더 좋은 방식이 무엇인지 고민해보겠습니다! 