### PR TITLE
✨feat: 댓글 페이지 이전 댓글 삭제 기능 구현

### DIFF
--- a/src/components/Channel/ChannelOpen/index.tsx
+++ b/src/components/Channel/ChannelOpen/index.tsx
@@ -1,15 +1,20 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Button from '@/components/Common/Button';
 import OpenChannel from '@/components/Common/CustomChannelIcon/OpenChannel';
 import useChannelQuery from '@/hooks/api/useChannelQuery';
 import { parsedColor } from '@/utils/parse';
 import { ChannelButton, OpenIcon } from './index.style';
 
-function ChannelOpen({ channelId }: Record<string, string>) {
+interface channelOpenProps {
+  channelId: string;
+  channelName: string;
+}
+
+function ChannelOpen({ channelId, channelName }: channelOpenProps) {
   const navigate = useNavigate();
-  const { channelId } = useParams();
-  const { data: channelInfo } = useChannelQuery(channelId ?? '');
+  const { data: channelInfo } = useChannelQuery(channelName ?? '');
   const channelColor = parsedColor(channelInfo?.description);
+
   return (
     <>
       <OpenIcon>
@@ -19,7 +24,9 @@ function ChannelOpen({ channelId }: Record<string, string>) {
       <ChannelButton>
         <Button
           onClick={() =>
-            navigate('/post/new', { state: { name: channelInfo.name } })
+            navigate('/post/new', {
+              state: { channelName, channelId }
+            })
           }
           content="마음 전달하기"
           size="md"

--- a/src/components/Post/Header/index.tsx
+++ b/src/components/Post/Header/index.tsx
@@ -3,7 +3,7 @@ import * as Style from './index.style';
 
 function Header() {
   const [userName, setUserName] = useState('최익');
-  console.log(setUserName);
+
   return (
     <>
       <Style.HeaderContainer>

--- a/src/components/Post/Warning/index.tsx
+++ b/src/components/Post/Warning/index.tsx
@@ -3,7 +3,7 @@ import * as Style from './index.style';
 
 function Warning() {
   const [isWarningMessage, setIsWarningMessage] = useState(true); // warning messsage를 위한 임시 state
-  console.log(setIsWarningMessage);
+
   const warningMessage = isWarningMessage
     ? '이 트리는 비공개 박으로, 메시지는\n박 주인에게만 보여져요.'
     : '이 트리는 공개 박으로, 메시지는\n모든 사람이 볼 수 있어요.';

--- a/src/components/PostComment/Header/index.tsx
+++ b/src/components/PostComment/Header/index.tsx
@@ -3,7 +3,7 @@ import * as Style from './index.style';
 
 function Header() {
   const [userName, setUserName] = useState('최익');
-  console.log(setUserName);
+
   return (
     <Style.HeaderContainer>
       <Style.HeaderInnerText>

--- a/src/components/PostComment/PrePost/index.style.tsx
+++ b/src/components/PostComment/PrePost/index.style.tsx
@@ -148,6 +148,7 @@ export const PreCommentContainer = styled.div`
 `;
 
 export const PrePostComment = styled.div`
+  position: relative;
   margin: auto 0;
   background-color: ${(props) => props.theme.palette.sub};
   font-size: 0.8rem;
@@ -156,11 +157,18 @@ export const PrePostComment = styled.div`
   height: auto;
   line-height: 1rem;
   margin-bottom: 0.6rem;
-  padding: 1rem 0.7rem;
+  padding: 1rem 2.5rem 1rem 0.7rem;
   box-sizing: border-box;
   border-radius: 10px;
 `;
 
 export const PrePostUserName = styled.span`
   font-weight: 800;
+`;
+
+export const CommentDeleteImg = styled.img`
+  position: absolute;
+  right: 1rem;
+  width: 1.2rem;
+  cursor: pointer;
 `;

--- a/src/components/PostComment/PrePost/index.tsx
+++ b/src/components/PostComment/PrePost/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import toast, { Toaster } from 'react-hot-toast';
 import { useAtomValue } from 'jotai';
+import { useCommentDeleteMutation } from '@/hooks/api/useCommentDeleteMutation';
 import { useGetPostDetailQuery } from '@/hooks/api/useGetPostDetailQuery';
 import { useLikeCreateMutation } from '@/hooks/api/useLikeCreateMutation';
 import { useLikeDeleteMutation } from '@/hooks/api/useLikeDeleteMutation';
@@ -32,7 +33,9 @@ function PrePost({ postId }: PrePostProps) {
   const { mutationLikeDelete } = useLikeDeleteMutation(postId); // 특정 포스트 좋아요 제거
   const { mutationPostDelete } = usePostDeleteMutation(); // 특정 포스트 제거
   const { mutationPostUpdate } = usePostUpdateMutation(); // 특정 포스트 수정
+  const { mutationCommentDelete } = useCommentDeleteMutation(postId); // 특정 댓글 제거
   const { data, isPending } = useGetPostDetailQuery(postId);
+  console.log(data);
 
   const {
     register,
@@ -91,6 +94,17 @@ function PrePost({ postId }: PrePostProps) {
       mutationPostDelete({
         JWTtoken,
         id: postId
+      });
+    }
+  };
+
+  const handleDeleteCommentClick = (e) => {
+    const deleteCheck = confirm('댓글 삭제하시겠습니까?');
+
+    if (deleteCheck) {
+      mutationCommentDelete({
+        JWTtoken,
+        id: e.target.dataset.id
       });
     }
   };
@@ -170,13 +184,18 @@ function PrePost({ postId }: PrePostProps) {
         </Style.LikeCommentContainer>
         <Style.PreCommentContainer>
           {data?.comments.map(
-            ({ comment }, idx) =>
+            ({ comment, _id }, idx) =>
               titleAndCommentParsing(comment) && (
                 <Style.PrePostComment key={idx}>
                   <Style.PrePostUserName>
                     {`${titleAndCommentParsing(comment).title} `}
                   </Style.PrePostUserName>
                   {titleAndCommentParsing(comment).comment}
+                  <Style.CommentDeleteImg
+                    src="/src/assets/delete.svg"
+                    data-id={_id}
+                    onClick={handleDeleteCommentClick}
+                  />
                 </Style.PrePostComment>
               )
           )}

--- a/src/components/PostComment/PrePost/index.tsx
+++ b/src/components/PostComment/PrePost/index.tsx
@@ -116,7 +116,6 @@ function PrePost({ postId }: PrePostProps) {
     }
   }, [isSubmitting]);
 
-
   return (
     <>
       <Style.PrePostAndCommentContainer>

--- a/src/components/PostComment/index.tsx
+++ b/src/components/PostComment/index.tsx
@@ -27,6 +27,7 @@ interface useFormProps {
 function PostComment() {
   const JWTtoken = useAtomValue(tokenAtom);
   const userId = useAtomValue(idAtom);
+
   const { postId } = useParams() as { postId: string };
   const { mutationCommentCreate } = usePostCommentCreateMutation(postId);
   const { data, isPending } = useUserInfomationQuery(userId);
@@ -35,7 +36,8 @@ function PostComment() {
     register,
     formState: { errors, isSubmitting, isSubmitSuccessful },
     handleSubmit,
-    reset
+    reset,
+    setValue
   } = useForm<useFormProps>({
     mode: 'onSubmit',
     defaultValues: {
@@ -46,6 +48,7 @@ function PostComment() {
 
   /** 댓글 작성 시 서버로 전송 */
   const onSubmit = (data: useFormProps) => {
+    console.log(data);
     mutationCommentCreate({
       JWTtoken,
       title: data.commentTitle,
@@ -53,6 +56,10 @@ function PostComment() {
       postId
     });
   };
+
+  useEffect(() => {
+    setValue('commentTitle', userId ? (data ? data.fullName : '') : '');
+  }, [userId, data]);
 
   useEffect(() => {
     if (isSubmitSuccessful) reset();

--- a/src/hooks/api/useCommentDeleteMutation.ts
+++ b/src/hooks/api/useCommentDeleteMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { postPostCommentDelete } from '@/api/post';
+
+interface mutationProprs {
+  JWTtoken: string;
+  id: string;
+}
+/** 댓글 삭제 mutation */
+export const useCommentDeleteMutation = (postId: string) => {
+  const queryClient = useQueryClient();
+
+  const commentDeleteMutation = useMutation({
+    mutationFn: ({ JWTtoken, id }: mutationProprs) =>
+      postPostCommentDelete(JWTtoken, id),
+    onSuccess: () => {
+      console.log('댓글이 정상적으로 삭제되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] });
+    },
+    onError: () => console.log('댓글이 정상적으로 삭제 되지 않았습니다.')
+  });
+
+  return { mutationCommentDelete: commentDeleteMutation.mutate };
+};

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -15,14 +15,14 @@ function Channel() {
     description: ''
   });
   const [isOpened, setIsOpened] = useState(false);
-  const { channelId } = useParams();
-  const { data: channelInfo } = useChannelQuery(channelId ?? '');
+  const { channelName } = useParams();
+  const { data: channelInfo } = useChannelQuery(channelName ?? '');
 
   useEffect(() => {
     if (channelInfo) setData(channelInfo);
   }, [channelInfo]);
 
-  if (channelId === undefined) {
+  if (channelName === undefined) {
     return <Navigate to="/" />;
   }
   const handleIconClick = (): void => {
@@ -41,7 +41,10 @@ function Channel() {
       {isOpened ? (
         <>
           <ChannelAnimation />
-          <ChannelOpen channelId={channelId} />
+          <ChannelOpen
+            channelId={channelInfo._id}
+            channelName={channelName}
+          />
         </>
       ) : (
         <ChannelClose handleIconClick={handleIconClick} />

--- a/src/pages/ChannelList/index.tsx
+++ b/src/pages/ChannelList/index.tsx
@@ -22,10 +22,9 @@ function ChannelList() {
       <ChannelIconList>
         {channelList?.map((channel: Channel) => (
           <div
-            key={`channel-${channel._id}`}
+            key={`channel-${channel.name}`}
             role="button">
-            <Link to={`/channel/${channel._id}`}>
-
+            <Link to={`/channel/${channel.name}`}>
               <ChannelIcon channel={channel} />
             </Link>
           </div>

--- a/src/pages/PostCreate/index.tsx
+++ b/src/pages/PostCreate/index.tsx
@@ -26,7 +26,7 @@ function PostCreate() {
     <>
       <Title>
         <h1>
-          <span>{state.name ?? '프룽'}</span>님께 보내는 주머니
+          <span>{state.channelName ?? '프룽'}</span>님께 보내는 주머니
         </h1>
         <span>주머니 색상을 선택해주세요</span>
       </Title>
@@ -57,7 +57,9 @@ function PostCreate() {
           content={'다음'}
           kind={'primary'}
           size="lg"
-          onClick={() => navigate('/post', { state: { color: color } })}
+          onClick={() =>
+            navigate(`/post/${state.channelId}`, { state: { color: color } })
+          }
         />
       </ChannelButton>
     </>

--- a/src/route/AppRouter.tsx
+++ b/src/route/AppRouter.tsx
@@ -59,7 +59,11 @@ const authRoutes: Array<RouteProps> = [
 // 모든 상태에서 접근 가능
 const commonRoutes: Array<RouteProps> = [
   { path: PATH.ROOT, exact: true, component: <ChannelList /> },
-  { path: `${PATH.CHANNEL}/:channelId`, exact: false, component: <Channel /> },
+  {
+    path: `${PATH.CHANNEL}/:channelName`,
+    exact: false,
+    component: <Channel />
+  },
   { path: PATH.POST_CREATE, exact: true, component: <PostCreate /> },
   { path: `${PATH.POST}/:channelId`, exact: true, component: <Post /> },
   { path: `${PATH.COMMENT}/:postId`, exact: true, component: <Comment /> }


### PR DESCRIPTION
## **📌** 작업 내용

- 기존 채널 페이지의 채널 이름을 위해 사용했던 `channelId` 네이밍을 `channeldName`으로 변경
- 기존 `channelId`를 사용한 경로 매변개수를 `channelName`으로 변경 -> 박 페이지의 url: `channelName`
- `userId` 여부에 따른 댓글창 title 편집 가능/불가 여부에 대한 버그 수정
- Comment 페이지의 이전 댓글 삭제 기능 추가
