### PR TITLE
✨ Feat:  Post 페이지 편지 작성 시 페이지 이동 및 성공 여부 Toast 노출 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-router-dom": "^5.3.3",
         "axios": "^1.6.2",
         "jotai": "^2.6.0",
+        "lottie-react": "^2.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.49.2",
@@ -12635,6 +12636,23 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/lottie-react": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lottie-react/-/lottie-react-2.4.0.tgz",
+      "integrity": "sha512-pDJGj+AQlnlyHvOHFK7vLdsDcvbuqvwPZdMlJ360wrzGFurXeKPr8SiRCjLf3LrNYKANQtSsh5dz9UYQHuqx4w==",
+      "dependencies": {
+        "lottie-web": "^5.10.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/lottie-web": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.12.2.tgz",
+      "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -26577,6 +26595,19 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lottie-react": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lottie-react/-/lottie-react-2.4.0.tgz",
+      "integrity": "sha512-pDJGj+AQlnlyHvOHFK7vLdsDcvbuqvwPZdMlJ360wrzGFurXeKPr8SiRCjLf3LrNYKANQtSsh5dz9UYQHuqx4w==",
+      "requires": {
+        "lottie-web": "^5.10.2"
+      }
+    },
+    "lottie-web": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.12.2.tgz",
+      "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="
     },
     "loupe": {
       "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.6.2",
     "jotai": "^2.6.0",
+    "lottie-react": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.49.2",

--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -26,7 +26,8 @@ export const postPostCreate = async (
   title: string,
   content: string,
   image: string | null,
-  channelId: string
+  channelId: string,
+  color: string
 ) => {
   const { data } = await axios.post('/api', {
     method: 'POST',
@@ -37,7 +38,8 @@ export const postPostCreate = async (
     data: {
       title: JSON.stringify({
         title,
-        content
+        content,
+        color
       }),
       image,
       channelId

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { Toaster } from 'react-hot-toast';
 import { toast } from 'react-hot-toast';
-import { useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 // import useChannelListQuery from '@/hooks/api/useChannelListQuery';
 // import { useGetPostDetailQuery } from '@/hooks/api/useGetPostDetailQuery';
@@ -28,7 +28,7 @@ export interface useFormProps {
 function Post() {
   const {
     register,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, isSubmitSuccessful },
     handleSubmit
   } = useForm<useFormProps>({
     mode: 'onSubmit',
@@ -40,6 +40,8 @@ function Post() {
   const JWTtoken = useAtomValue(tokenAtom);
   const { channelId } = useParams();
   const { mutationPostCreate } = usePostCreateMutation();
+  const navigate = useNavigate();
+  const { state } = useLocation();
 
   /** 채널 리스트 */
   // const { data: channelListData } = useChannelListQuery();
@@ -66,7 +68,13 @@ function Post() {
         ? toast.error(errors.letterTitle.message as string)
         : null;
     }
-  }, [isSubmitting]);
+
+    if (isSubmitSuccessful) {
+      toast.success('편지 작성에 성공하였습니다!');
+
+      navigate(`/channel/${state.channelName}`);
+    }
+  }, [isSubmitting, isSubmitSuccessful]);
 
   return (
     <>

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -4,7 +4,7 @@ import { Toaster } from 'react-hot-toast';
 import { toast } from 'react-hot-toast';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-// import useChannelListQuery from '@/hooks/api/useChannelListQuery';
+import useChannelListQuery from '@/hooks/api/useChannelListQuery';
 // import { useGetPostDetailQuery } from '@/hooks/api/useGetPostDetailQuery';
 import { usePostCreateMutation } from '@/hooks/api/usePostCreateMutation';
 import { tokenAtom } from '@/store/auth';
@@ -44,7 +44,8 @@ function Post() {
   const { state } = useLocation();
 
   /** 채널 리스트 */
-  // const { data: channelListData } = useChannelListQuery();
+  const { data: channelListData } = useChannelListQuery();
+  console.log(channelListData);
 
   /** 포스트 작성 시 서버로 전송 */
   const onSubmit = (submitData: useFormProps) => {
@@ -54,7 +55,8 @@ function Post() {
         title: submitData.letterTitle,
         content: submitData.letterComment,
         image: null,
-        channelId
+        channelId,
+        color: state.color
       });
   };
 

--- a/src/hooks/api/usePostCreateMutation.ts
+++ b/src/hooks/api/usePostCreateMutation.ts
@@ -7,6 +7,7 @@ interface mutationProps {
   content: string;
   image: string | null;
   channelId: string;
+  color: string;
 }
 
 /** 포스트 생성 mutation */
@@ -17,9 +18,10 @@ export const usePostCreateMutation = () => {
       title,
       content,
       image,
-      channelId
+      channelId,
+      color
     }: mutationProps) =>
-      postPostCreate(JWTtoken, title, content, image, channelId),
+      postPostCreate(JWTtoken, title, content, image, channelId, color),
     onSuccess: () => console.log('편지가 정상적으로 전달되었습니다.'),
     onError: (error) => console.log('편지가 전달되지 못하였습니다.', error)
   });

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -31,8 +31,7 @@ function Channel() {
 
   return (
     <Background
-      selectedValue={data.description && parsedBackground(data.description)}
-    >
+      selectedValue={data.description && parsedBackground(data.description)}>
       <Title>
         <h1>
           <span>{data.name}</span>님의 박

--- a/src/pages/PostCreate/index.tsx
+++ b/src/pages/PostCreate/index.tsx
@@ -58,7 +58,9 @@ function PostCreate() {
           kind={'primary'}
           size="lg"
           onClick={() =>
-            navigate(`/post/${state.channelId}`, { state: { color: color } })
+            navigate(`/post/${state.channelId}`, {
+              state: { color: color, channelName: state.channelName }
+            })
           }
         />
       </ChannelButton>


### PR DESCRIPTION
## **📌** 작업 내용

- 편지 작성 후 성공 시 성공 여부 Toast 노출 및 포스트를 전달 할 박(채널주인) 페이지로 이동
- 편지 작성 시 복 주머니 생상 `/post/create` API의 title 속성에 JSON 파싱하여 color 속성 추가 하였음
- Post 페이지에서 박 페이지로 routing 하기 위해 `/post/new`의 navigate에서 `/post/channelId` 의 Post 페이지로 channelName 속성 추가로 전달
