### PR TITLE
💄design: 채널 및 알람 페이지 디자인 리팩토링

### DIFF
--- a/src/components/Alarm/AlarmItem/index.style.tsx
+++ b/src/components/Alarm/AlarmItem/index.style.tsx
@@ -22,8 +22,10 @@ export const Info = styled.div<{ seen: boolean }>`
     ${({ theme }) => theme.typography.label};
   }
 `;
-export const Content = styled.div`
+export const Content = styled.div<{ seen: boolean }>`
   display: flex;
+  color: ${({ theme, seen }) =>
+    seen ? theme.palette.gray_2 : theme.palette.gray_1};
   gap: 1rem;
   div {
     ${({ theme }) => theme.typography.description2};
@@ -35,7 +37,6 @@ export const Content = styled.div`
     padding: 0.1rem;
   }
   span {
-    color: ${({ theme }) => theme.palette.gray_1};
     ${({ theme }) => theme.typography.mypage_small};
   }
 `;

--- a/src/components/Alarm/AlarmItem/index.tsx
+++ b/src/components/Alarm/AlarmItem/index.tsx
@@ -32,7 +32,7 @@ function AlarmItem({ info }: Prop) {
 
   return (
     <Style.Notification onClick={handleClickItem}>
-      <Style.Content>
+      <Style.Content seen={seen}>
         <img
           src={`${import.meta.env.VITE_PUBLIC_URL}/images/alarm/${type}.svg`}
           alt="alarm-image"
@@ -44,7 +44,10 @@ function AlarmItem({ info }: Prop) {
       </Style.Content>
       <Style.Info seen={seen}>
         <div>{dayjs(createdAt).fromNow()}</div>
-        <img src={New} />
+        <img
+          src={New}
+          alt="unread notification"
+        />
       </Style.Info>
     </Style.Notification>
   );

--- a/src/components/Channel/ChannelOption/index.style.tsx
+++ b/src/components/Channel/ChannelOption/index.style.tsx
@@ -6,22 +6,22 @@ export const OptionBox = styled.div`
   gap: 0.2rem;
   z-index: 1;
 `;
-export const Option = styled.div`
+export const Option = styled.div<{
+  darkMode: boolean;
+}>`
   ${({ theme }) => theme.typography.description};
   display: flex;
   border: 1px solid ${({ theme }) => theme.palette.gray_2};
   border-radius: 10px;
   padding: 0.5rem;
   gap: 0.2rem;
-  img {
-    width: 1.3rem;
-  }
   div {
     padding: 0.2rem;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
     align-items: center;
-    color: ${({ theme }) => theme.palette.gray_2};
+    color: ${({ theme, darkMode }) =>
+      darkMode ? theme.palette.gray_2 : theme.palette.gray_1};
   }
 `;

--- a/src/components/Channel/ChannelOption/index.tsx
+++ b/src/components/Channel/ChannelOption/index.tsx
@@ -1,23 +1,42 @@
-import Private from '@/assets/Private.svg';
-import Public from '@/assets/Public.svg';
+import { IoLockClosedOutline, IoLockOpenOutline } from 'react-icons/io5';
+import { useAtomValue } from 'jotai/react';
+import { darkAtom } from '@/store/theme';
+import { theme } from '@/theme';
 import { parsedDescription } from '@/utils/parse';
 import { Option, OptionBox } from './index.style';
 
 interface Props {
   description: string;
 }
+
 function ChannelOption({ description }: Props) {
+  const darkMode = useAtomValue(darkAtom);
   const result = parsedDescription(description);
+
+  const getPublicIcon = () => (
+    <IoLockOpenOutline
+      size={28}
+      color={darkMode ? theme.palette.gray_2 : theme.palette.dark}
+    />
+  );
+
+  const getPrivateIcon = () => (
+    <IoLockClosedOutline
+      size={28}
+      color={darkMode ? theme.palette.gray_2 : theme.palette.dark}
+    />
+  );
+
   return (
     <>
       <OptionBox>
-        <Option>
+        <Option darkMode={darkMode}>
           <div>열람</div>
-          <img src={result?.allowViewAll ? Public : Private} />
+          {result?.allowViewAll ? getPublicIcon() : getPrivateIcon()}
         </Option>
-        <Option>
+        <Option darkMode={darkMode}>
           <div>작성</div>
-          <img src={result?.allowWriteAll ? Public : Private} />
+          {result?.allowWriteAll ? getPublicIcon() : getPrivateIcon()}
         </Option>
       </OptionBox>
     </>

--- a/src/components/ChannelTemplate/AccessCandidate/index.tsx
+++ b/src/components/ChannelTemplate/AccessCandidate/index.tsx
@@ -1,5 +1,4 @@
-import Private from '@/assets/Private.svg';
-import Public from '@/assets/Public.svg';
+import { IoLockClosedOutline, IoLockOpenOutline } from 'react-icons/io5';
 import { theme } from '@/theme';
 import { css } from '@emotion/react';
 import { Container } from './index.style';
@@ -19,9 +18,18 @@ function AccessCandidate({ security, selected, text, onClick }: Props) {
   return (
     <Container
       onClick={onClick}
-      css={selected === security && selectedStyle}
-    >
-      <img src={security ? Private : Public} />
+      css={selected === security && selectedStyle}>
+      {security ? (
+        <IoLockOpenOutline
+          size={28}
+          color={theme.palette.dark}
+        />
+      ) : (
+        <IoLockClosedOutline
+          size={28}
+          color={theme.palette.dark}
+        />
+      )}
       <span>{text}</span>
     </Container>
   );

--- a/src/components/ChannelTemplate/SelectBackground/index.style.tsx
+++ b/src/components/ChannelTemplate/SelectBackground/index.style.tsx
@@ -13,18 +13,12 @@ export const Background = styled.div<{ selectedValue: BgName }>`
 `;
 
 export const Item = styled.img<{
-  size: string;
   styleOption?: { [key: string]: string };
 }>`
-  margin: 0.5rem;
-  width: ${({ size }) => `calc(${size} + 3rem)`};
-  height: ${({ size }) => `calc(${size} + 3rem)`};
-  @media (max-width: 767px) {
-    width: ${({ size }) => size};
-    height: ${({ size }) => size};
-  }
+  width: 90%;
+  object-content: fill;
+  height: 90%;
   border-radius: 10px;
-  object-fit: fill;
   box-shadow: 1px 1px 7px ${({ theme }) => theme.palette.gray_2};
   ${({ styleOption }) => styleOption}
 `;

--- a/src/components/ChannelTemplate/SelectBackground/index.tsx
+++ b/src/components/ChannelTemplate/SelectBackground/index.tsx
@@ -27,7 +27,6 @@ function SelectBackground({ option, setOption }: Props) {
         {Object.keys(BgType).map((item) => (
           <Li key={`channel-background${item}`}>
             <Item
-              size={'5.5rem'}
               css={option.background === item && selectedStyle}
               src={`${
                 import.meta.env.VITE_PUBLIC_URL

--- a/src/components/ChannelTemplate/SelectBackground/index.tsx
+++ b/src/components/ChannelTemplate/SelectBackground/index.tsx
@@ -4,6 +4,7 @@ import { ChannelIconList, Title } from '@/pages/ChannelList/index.style.tsx';
 import { channelNameAtom } from '@/store/auth';
 import { ChannelOptionType } from '@/types/channel';
 import { selectedStyle } from '../SelectColor';
+import { Li } from '../SelectColor/index.style';
 import { Background, Item } from './index.style';
 import { BgName, BgType } from './type';
 
@@ -24,7 +25,7 @@ function SelectBackground({ option, setOption }: Props) {
       </Title>
       <ChannelIconList>
         {Object.keys(BgType).map((item) => (
-          <div key={`channel-background${item}`}>
+          <Li key={`channel-background${item}`}>
             <Item
               size={'5.5rem'}
               css={option.background === item && selectedStyle}
@@ -36,7 +37,7 @@ function SelectBackground({ option, setOption }: Props) {
                 setOption({ ...option, background: item as BgName })
               }
             />
-          </div>
+          </Li>
         ))}
       </ChannelIconList>
     </Background>

--- a/src/components/ChannelTemplate/SelectColor/index.style.tsx
+++ b/src/components/ChannelTemplate/SelectColor/index.style.tsx
@@ -7,18 +7,12 @@ export const Li = styled.li`
   align-items: center;
 `;
 export const Item = styled.div`
+  width: 90%;
+  height: 90%;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin: 0.5rem;
-  padding: 0.2rem;
   background-color: rgba(0, 0, 0, 0.2);
-  width: 8.625rem;
-  height: 8.625rem;
-  @media (max-width: 767px) {
-    width: 5.625rem;
-    height: 5.625rem;
-  }
   border-radius: 10px;
 `;

--- a/src/components/ChannelTemplate/SelectColor/index.style.tsx
+++ b/src/components/ChannelTemplate/SelectColor/index.style.tsx
@@ -1,5 +1,11 @@
 import styled from '@emotion/styled';
 
+export const Li = styled.li`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
 export const Item = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/ChannelTemplate/SelectColor/index.tsx
+++ b/src/components/ChannelTemplate/SelectColor/index.tsx
@@ -7,7 +7,7 @@ import { theme } from '@/theme';
 import { ChannelOptionType } from '@/types/channel';
 import { css } from '@emotion/react';
 import { Background } from '../SelectBackground/index.style';
-import { Item } from './index.style';
+import { Item, Li } from './index.style';
 import { ColorName, ColorType } from './type';
 
 interface Props {
@@ -38,13 +38,16 @@ function SelectColor({ option, setOption }: Props) {
       </Title>
       <ChannelIconList>
         {Object.keys(ColorType).map((color) => (
-          <Item
-            role="button"
-            key={`channel-color${color}`}
-            css={option.color === color && selectedStyle}
-            onClick={() => setOption({ ...option, color: color as ColorName })}>
-            <CustomChannelIcon color={ColorType[color as ColorName]} />
-          </Item>
+          <Li key={`channel-color${color}`}>
+            <Item
+              role="button"
+              css={option.color === color && selectedStyle}
+              onClick={() =>
+                setOption({ ...option, color: color as ColorName })
+              }>
+              <CustomChannelIcon color={ColorType[color as ColorName]} />
+            </Item>
+          </Li>
         ))}
       </ChannelIconList>
     </Background>

--- a/src/components/ChannelTemplate/SelectColor/index.tsx
+++ b/src/components/ChannelTemplate/SelectColor/index.tsx
@@ -16,12 +16,6 @@ interface Props {
 }
 
 export const selectedStyle = css`
-  width: calc(8.625rem - 7px);
-  height: calc(8.625rem - 7px);
-  @media (max-width: 767px) {
-    width: calc(5.625rem - 7px);
-    height: calc(5.625rem - 7px);
-  }
   border: 3px solid ${theme.palette.main};
 `;
 

--- a/src/components/Common/NotificationMenu/index.style.tsx
+++ b/src/components/Common/NotificationMenu/index.style.tsx
@@ -1,8 +1,13 @@
 import styled from '@emotion/styled';
 
-export const Button = styled.div`
+export const Button = styled.div<{ isUnread: boolean }>`
   position: absolute;
   padding: 2rem 1rem;
   right: 3rem;
   z-index: 10;
+  img {
+    position: absolute;
+    right: 1rem;
+    visibility: ${({ isUnread }) => (isUnread ? 'block' : 'hidden')};
+  }
 `;

--- a/src/components/Common/NotificationMenu/index.tsx
+++ b/src/components/Common/NotificationMenu/index.tsx
@@ -9,9 +9,7 @@ import { Button } from './index.style';
 
 function NotificationMenu() {
   const [visible, handleModalClick] = useModal();
-
   const darkMode = useAtomValue(darkAtom);
-
   const handleClickButton = (e: React.MouseEvent<HTMLElement>) => {
     handleModalClick(e);
   };

--- a/src/components/Common/NotificationMenu/index.tsx
+++ b/src/components/Common/NotificationMenu/index.tsx
@@ -1,27 +1,44 @@
 import { IoNotificationsOutline } from 'react-icons/io5';
 import { useAtomValue } from 'jotai';
 import AlarmList from '@/components/Alarm/AlarmList';
+import useGetNotifications from '@/hooks/api/useGetNotifications';
 import useModal from '@/hooks/useModal';
+import New from '@/assets/New.svg';
 import { darkAtom } from '@/store/theme';
 import { theme } from '@/theme';
+import { Notification } from '@/types/ResponseType';
 import Modal from '../Modal';
 import { Button } from './index.style';
 
 function NotificationMenu() {
   const [visible, handleModalClick] = useModal();
   const darkMode = useAtomValue(darkAtom);
+  const { data } = useGetNotifications();
+
   const handleClickButton = (e: React.MouseEvent<HTMLElement>) => {
     handleModalClick(e);
+  };
+
+  const checkUnreadNotification = () => {
+    const filteredNotification = data?.filter(
+      (notification: Notification) => notification.seen === false
+    );
+    return filteredNotification.length > 0;
   };
 
   return (
     <>
       <Button
+        isUnread={checkUnreadNotification()}
         role="button"
         onClick={handleClickButton}>
         <IoNotificationsOutline
           size={28}
           color={darkMode ? theme.palette.sub : theme.palette.dark}
+        />
+        <img
+          src={New}
+          alt="unread notification"
         />
       </Button>
       {visible && (

--- a/src/components/Common/NotificationMenu/index.tsx
+++ b/src/components/Common/NotificationMenu/index.tsx
@@ -23,7 +23,7 @@ function NotificationMenu() {
     const filteredNotification = data?.filter(
       (notification: Notification) => notification.seen === false
     );
-    return filteredNotification.length > 0;
+    return filteredNotification?.length > 0;
   };
 
   return (

--- a/src/hooks/api/useCheckNotifications.ts
+++ b/src/hooks/api/useCheckNotifications.ts
@@ -1,11 +1,13 @@
 import { toast } from 'react-hot-toast';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { checkNotifications } from '@/api/user';
 
 export const useCheckNotifications = () => {
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: checkNotifications,
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifycaitons'] });
       toast.success('알람을 모두 읽음처리에 성공했습니다.');
     },
     onError: (e) => {

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -23,7 +23,6 @@ function Channel() {
 
   useEffect(() => {
     const background: BgName = parsedBackground(data?.description);
-
     if ((BgType[background] === 'dark') !== darkMode) {
       toggleTheme();
       setmode(true);
@@ -33,7 +32,7 @@ function Channel() {
         toggleTheme();
       }
     };
-  }, [darkMode, mode, toggleTheme]);
+  }, [data?.description]);
 
   if (channelName === undefined) {
     return <Navigate to="/" />;

--- a/src/pages/ChannelList/index.style.tsx
+++ b/src/pages/ChannelList/index.style.tsx
@@ -39,8 +39,14 @@ export const Body = styled.div`
 
 export const ChannelIconList = styled.ul`
   margin: auto;
+  padding: 1rem;
   width: 90%;
+  max-height: 65vh;
+  @media (max-width: 767px) {
+    max-height: 60vh;
+  }
   color: white;
   display: grid;
+  overflow: scroll;
   grid-template-columns: repeat(3, 33%);
 `;

--- a/src/pages/ChannelList/index.style.tsx
+++ b/src/pages/ChannelList/index.style.tsx
@@ -36,19 +36,11 @@ export const Body = styled.div`
   padding-top: 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.2);
 `;
+
 export const ChannelIconList = styled.ul`
   margin: auto;
-  width: 100%;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
-  height: 74vh;
-  @media (max-width: 767px) {
-    height: 63vh;
-  }
+  width: 90%;
   color: white;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(auto-fill, minmax(8.5rem, auto));
+  grid-template-columns: repeat(3, 33%);
 `;

--- a/src/pages/ChannelList/index.style.tsx
+++ b/src/pages/ChannelList/index.style.tsx
@@ -48,5 +48,8 @@ export const ChannelIconList = styled.ul`
   color: white;
   display: grid;
   overflow: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
   grid-template-columns: repeat(3, 33%);
 `;

--- a/src/pages/ChannelList/index.tsx
+++ b/src/pages/ChannelList/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai/react';
+import { Li } from '@/components/ChannelTemplate/SelectColor/index.style';
 import Button from '@/components/Common/Button';
 import ShortLogo from '@/components/Common/Logo/ShortLogo';
 import SearchBar from '@/components/Common/SearchBar';
@@ -71,13 +72,13 @@ function ChannelList() {
         <ChannelIconList>
           {channels &&
             [...channels].reverse().map((channel: Channel) => (
-              <div
+              <Li
                 key={`channel-${channel._id}`}
                 role="button">
                 <Link to={`/channel/${channel.name}`}>
                   <ChannelIcon channel={channel} />
                 </Link>
-              </div>
+              </Li>
             ))}
         </ChannelIconList>
       </Body>

--- a/src/pages/PostCreate/index.tsx
+++ b/src/pages/PostCreate/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Item } from '@/components/ChannelTemplate/SelectBackground/index.style';
+import { Li } from '@/components/ChannelTemplate/SelectColor/index.style';
 import {
   ColorName,
   ColorType
@@ -37,19 +38,21 @@ function PostCreate() {
       </Title>
       <ChannelIconList>
         {Object.keys(ColorType).map((colorName) => (
-          <Item
-            size={'2rem'}
-            role="button"
+          <Li
             key={`letter-color${colorName}`}
-            src={`${
-              import.meta.env.VITE_PUBLIC_URL
-            }/images/letter/${colorName}.png`}
-            css={colorName === color && selectedStyle}
             onClick={() => setColor(colorName as ColorName)}
-            styleOption={{
-              padding: '2rem'
-            }}
-          />
+            role="button">
+            <Item
+              size={'2rem'}
+              src={`${
+                import.meta.env.VITE_PUBLIC_URL
+              }/images/letter/${colorName}.png`}
+              css={colorName === color && selectedStyle}
+              styleOption={{
+                padding: '2rem'
+              }}
+            />
+          </Li>
         ))}
       </ChannelIconList>
       <ChannelButton>

--- a/src/pages/PostCreate/index.tsx
+++ b/src/pages/PostCreate/index.tsx
@@ -14,12 +14,6 @@ import { ChannelButton } from '../ChannelTemplate/index.style';
 import { Body } from './index.style';
 
 export const selectedStyle = css`
-  width: calc(5rem - 7px);
-  height: calc(5rem - 7px);
-  @media (max-width: 767px) {
-    width: calc(2rem - 7px);
-    height: calc(2rem - 7px);
-  }
   border: 3px solid ${theme.palette.main};
 `;
 
@@ -43,13 +37,14 @@ function PostCreate() {
             onClick={() => setColor(colorName as ColorName)}
             role="button">
             <Item
-              size={'2rem'}
               src={`${
                 import.meta.env.VITE_PUBLIC_URL
               }/images/letter/${colorName}.png`}
               css={colorName === color && selectedStyle}
               styleOption={{
-                padding: '2rem'
+                padding: '1rem',
+                width: 'calc(90% - 2.5rem)',
+                height: 'calc(90% - 2.5rem)'
               }}
             />
           </Li>

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -31,11 +31,6 @@ export const parsedPosts = (posts: Post[]) => {
 };
 
 export const getImageUrl = (name: string) => {
-  const url = `../assets/images/background/${name}.png`;
-  const parsedUrl = new URL(url, import.meta.url).href;
-  const url2 = `/assets/images/background/${name}.png`;
-  console.log(parsedUrl);
-  const parsedUrl2 = new URL(url2, import.meta.url).href;
-  console.log(parsedUrl, parsedUrl2);
-  return parsedUrl2;
+  const url = `/assets/images/background/${name}.png`;
+  return new URL(url, import.meta.url).href;
 };


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] 자물쇠 아이콘을 reacticon으로 변경

  - <img width="304" alt="스크린샷 2024-01-17 오전 6 36 35" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/75975946/e17a4903-875e-472d-bddf-adb2fd71e3d2">

  - <img width="297" alt="스크린샷 2024-01-17 오전 6 37 03" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/75975946/2cd0ec02-0683-4658-8bc1-2d2bc4a8f463">

  - <img width="294" alt="스크린샷 2024-01-17 오전 6 37 15" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/75975946/7e49bf1f-372e-4158-8922-bf61e534ebd5">

- [x] 매끄러운 ui를 위해 %로 수정 및 overflow영역을 정리
  - <img width="369" alt="스크린샷 2024-01-17 오전 7 44 16" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/75975946/0d30fd58-fd7b-4143-a951-e37848fc4ee8">

- [x] 알림 읽음처리 글자 색상 추가 변경
  - <img width="318" alt="스크린샷 2024-01-17 오전 8 01 29" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/75975946/d5ecccb1-e3ca-4a99-a8b8-ffde88a56e58">
- [x] 읽지 않은 알람 표시
  - <img width="98" alt="스크린샷 2024-01-17 오전 8 20 13" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/75975946/dbc34c42-2032-4b28-afec-f7e7bbbeedfb">


## 🚦 특이 사항

> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
- 열람 및 작성 아이콘위치
1. 유경언니 말한대로 해당 위치를 최상단 중간으로 옮기려했는데
2. 모바일 화면에서는 알람과, 햄버거바 아이콘이 둘다 존재하는 경우 좁아서 위치 변경이 어렵더라고요! 
3. 가려져도 노출될 수 있도록 글자색상을 눈에 잘보이게 변경했습니다. 좋은 위치 추천해주시면 바로 반영하겠습니답