### PR TITLE
🔨refactor: 메세지 페이지의 컴포넌트 key 누락 및 특정 유저 정보 요청 수정

### DIFF
--- a/src/components/Message/DM/index.tsx
+++ b/src/components/Message/DM/index.tsx
@@ -47,11 +47,11 @@ function DM({ darkMode, receiverData }: DMprops) {
       </Style.IntroduceContainer>
       {messageData &&
         messageData.map(({ sender, message }, idx) => (
-          <>
+          <Style.MessageContainer
+            isOrder={sender._id !== userId}
+            key={idx}>
             {userId && sender._id !== userId ? (
-              <Style.MessageContainer
-                isOrder={true}
-                key={idx}>
+              <>
                 <Style.UserProfile isSize={2}>
                   <ProfileImg
                     width={2}
@@ -61,11 +61,9 @@ function DM({ darkMode, receiverData }: DMprops) {
                   />
                 </Style.UserProfile>
                 <Style.Message darkMode={darkMode}>{message}</Style.Message>
-              </Style.MessageContainer>
+              </>
             ) : (
-              <Style.MessageContainer
-                isOrder={false}
-                key={idx}>
+              <>
                 {readCheck(idx, messageData)}
                 <Style.Message darkMode={darkMode}>{message}</Style.Message>
                 <Style.UserProfile isSize={2}>
@@ -84,9 +82,9 @@ function DM({ darkMode, receiverData }: DMprops) {
                     }
                   />
                 </Style.UserProfile>
-              </Style.MessageContainer>
+              </>
             )}
-          </>
+          </Style.MessageContainer>
         ))}
       <div ref={underScrollRef}></div>
     </>

--- a/src/hooks/api/useUser.ts
+++ b/src/hooks/api/useUser.ts
@@ -4,7 +4,8 @@ import { getUser } from '@/api/user';
 function useUser(userId: string) {
   return useQuery({
     queryKey: ['user', userId] as const,
-    queryFn: () => getUser(userId)
+    queryFn: () => getUser(userId),
+    enabled: !!userId
   });
 }
 


### PR DESCRIPTION
## **📌** 작업 내용

- 메세지 페이지의 반복되는 DM 컴포넌트의 누락된 key 추가
   - 프래그먼트로 감싸져있던 컴포넌트를 컨테이너 컴포넌트로 감싸았음.
- 특정 유저의 정보를 가져오기 위한 요청 데이터인 userId의 데이터 타입이 undefined라서 잘못 요청되는 에러 수정 
```javascript
import { useQuery } from '@tanstack/react-query';
import { getUser } from '@/api/user';

function useUser(userId: string) {
  return useQuery({
    queryKey: ['user', userId] as const,
    queryFn: () => getUser(userId),
    enabled: !!userId // userId가 undefined일 경우 요청 X
  });
}

export default useUser;

```