### PR TITLE
🐛fix: 본인 채널임에도 편지 공개 여부가 비공개 일시, 편지를 볼 수 없는 버그 수정

### DIFF
--- a/src/components/Channel/ChannelPosts/index.tsx
+++ b/src/components/Channel/ChannelPosts/index.tsx
@@ -49,7 +49,7 @@ function ChannelPosts({
   }, [posts]);
 
   const handleClickLetter = (post: FilteredPost) => {
-    if (!allowViewAll)
+    if (!allowViewAll && !isMyChannel)
       return toast.error('편지 공개를 허용하지않은 채널이에요.');
 
     const { title, content, color, postId } = post;


### PR DESCRIPTION
## **📌** 작업 내용

- 본인 채널임에도 편지 공개 여부가 비공개 일시, 편지를 볼 수 없는 버그 수정
```javascript
// 기존 코드 중 본인 채널 여부를 확인 한 isMyChannel 변수를 사용하여 버그 해결 
 if (!allowViewAll && !isMyChannel)
      return toast.error('편지 공개를 허용하지않은 채널이에요.');
```

