### PR TITLE
🔨Refactor: Textarea 컴포넌트에 Compound Component Pattern 적용

### DIFF
--- a/src/components/Common/Textarea/Button/Complete/index.style.tsx
+++ b/src/components/Common/Textarea/Button/Complete/index.style.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const CompleteButton = styled.img`
+  position: absolute;
+  right: 2.5rem;
+  bottom: 0.5rem;
+  width: 1.2rem;
+  cursor: pointer;
+  filter: invert(53%) sepia(49%) saturate(669%) hue-rotate(122deg)
+    brightness(95%) contrast(98%);
+`;

--- a/src/components/Common/Textarea/Button/Complete/index.tsx
+++ b/src/components/Common/Textarea/Button/Complete/index.tsx
@@ -1,0 +1,17 @@
+import completeIcon from '@/assets/complete.svg';
+import * as Style from './index.style';
+
+interface CompleteButtonProps {
+  onClick: () => void;
+}
+
+function CompleteButton({ onClick }: CompleteButtonProps) {
+  return (
+    <Style.CompleteButton
+      src={completeIcon}
+      onClick={onClick}
+    />
+  );
+}
+
+export default CompleteButton;

--- a/src/components/Common/Textarea/Button/Delete/index.style.tsx
+++ b/src/components/Common/Textarea/Button/Delete/index.style.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const DeleteButton = styled.img`
+  position: absolute;
+  right: 1rem;
+  bottom: 0.5rem;
+  width: 1.2rem;
+  cursor: pointer;
+  filter: invert(53%) sepia(49%) saturate(669%) hue-rotate(122deg)
+    brightness(95%) contrast(98%);
+`;

--- a/src/components/Common/Textarea/Button/Delete/index.tsx
+++ b/src/components/Common/Textarea/Button/Delete/index.tsx
@@ -1,0 +1,17 @@
+import deleteIcon from '@/assets/delete.svg';
+import * as Style from './index.style';
+
+interface DeleteButtonProps {
+  onClick: () => void;
+}
+
+function DeleteButton({ onClick }: DeleteButtonProps) {
+  return (
+    <Style.DeleteButton
+      src={deleteIcon}
+      onClick={onClick}
+    />
+  );
+}
+
+export default DeleteButton;

--- a/src/components/Common/Textarea/Button/Edit/index.style.tsx
+++ b/src/components/Common/Textarea/Button/Edit/index.style.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const EditButton = styled.img`
+  position: absolute;
+  right: 2.5rem;
+  bottom: 0.5rem;
+  width: 1.2rem;
+  cursor: pointer;
+  filter: invert(53%) sepia(49%) saturate(669%) hue-rotate(122deg)
+    brightness(95%) contrast(98%);
+`;

--- a/src/components/Common/Textarea/Button/Edit/index.tsx
+++ b/src/components/Common/Textarea/Button/Edit/index.tsx
@@ -1,0 +1,17 @@
+import editIcon from '@/assets/edit.svg';
+import * as Style from './index.style';
+
+interface EditButtonProps {
+  onClick: () => void;
+}
+
+function EditButton({ onClick }: EditButtonProps) {
+  return (
+    <Style.EditButton
+      src={editIcon}
+      onClick={onClick}
+    />
+  );
+}
+
+export default EditButton;

--- a/src/components/Common/Textarea/TextareaContent.tsx
+++ b/src/components/Common/Textarea/TextareaContent.tsx
@@ -1,0 +1,18 @@
+import { TextareaProps } from './index';
+import * as Style from './index.style';
+
+function TextareaContent({ darkMode, register, placeholder }: TextareaProps) {
+  return (
+    <Style.TextareaContent
+      darkMode={darkMode}
+      placeholder={placeholder}
+      {...(register && {
+        ...register('letterContent', {
+          required: '작성자명은 반드시 입력해야합니다.'
+        })
+      })}
+    />
+  );
+}
+
+export default TextareaContent;

--- a/src/components/Common/Textarea/TextareaContent.tsx
+++ b/src/components/Common/Textarea/TextareaContent.tsx
@@ -1,7 +1,10 @@
-import { TextareaProps } from './index';
+import { useContext } from 'react';
+import { TextareaContext, TextareaProps } from './index';
 import * as Style from './index.style';
 
-function TextareaContent({ darkMode, register, placeholder }: TextareaProps) {
+function TextareaContent({ register, placeholder }: TextareaProps) {
+  const { darkMode } = useContext(TextareaContext);
+
   return (
     <Style.TextareaContent
       darkMode={darkMode}

--- a/src/components/Common/Textarea/TextareaContent.tsx
+++ b/src/components/Common/Textarea/TextareaContent.tsx
@@ -5,20 +5,28 @@ import * as Style from './index.style';
 
 function TextareaContent<T extends FieldValues>({
   register,
+  registerOptions,
   placeholder,
-  formKey
+  formKey,
+  width,
+  height,
+  readonly = false,
+  className = ``
 }: TextareaProps<T>) {
   const { darkMode } = useContext(TextareaContext);
 
   return (
     <Style.TextareaContent
       darkMode={darkMode}
+      readOnly={readonly}
       placeholder={placeholder}
-      {...(register && {
-        ...register(formKey, {
-          required: '작성자명은 반드시 입력해야합니다.'
-        })
-      })}
+      {...(register &&
+        formKey && {
+          ...register(formKey, registerOptions)
+        })}
+      width={width}
+      height={height}
+      className={className}
     />
   );
 }

--- a/src/components/Common/Textarea/TextareaContent.tsx
+++ b/src/components/Common/Textarea/TextareaContent.tsx
@@ -1,8 +1,13 @@
 import { useContext } from 'react';
+import { FieldValues } from 'react-hook-form';
 import { TextareaContext, TextareaProps } from './index';
 import * as Style from './index.style';
 
-function TextareaContent({ register, placeholder }: TextareaProps) {
+function TextareaContent<T extends FieldValues>({
+  register,
+  placeholder,
+  formKey
+}: TextareaProps<T>) {
   const { darkMode } = useContext(TextareaContext);
 
   return (
@@ -10,7 +15,7 @@ function TextareaContent({ register, placeholder }: TextareaProps) {
       darkMode={darkMode}
       placeholder={placeholder}
       {...(register && {
-        ...register('letterContent', {
+        ...register(formKey, {
           required: '작성자명은 반드시 입력해야합니다.'
         })
       })}

--- a/src/components/Common/Textarea/TextareaTitle.tsx
+++ b/src/components/Common/Textarea/TextareaTitle.tsx
@@ -1,0 +1,26 @@
+import { TextareaProps } from './index';
+import * as Style from './index.style';
+
+function TextareaTitle({
+  darkMode,
+  value,
+  register,
+  placeholder,
+  maxLength
+}: TextareaProps) {
+  return (
+    <Style.TextareaTitle
+      darkMode={darkMode}
+      value={value}
+      placeholder={placeholder}
+      maxLength={maxLength}
+      {...(register && {
+        ...register('letterTitle', {
+          required: '작성자명은 반드시 입력해야합니다.'
+        })
+      })}
+    />
+  );
+}
+
+export default TextareaTitle;

--- a/src/components/Common/Textarea/TextareaTitle.tsx
+++ b/src/components/Common/Textarea/TextareaTitle.tsx
@@ -1,13 +1,14 @@
-import { TextareaProps } from './index';
+import { useContext } from 'react';
+import { TextareaContext, TextareaProps } from './index';
 import * as Style from './index.style';
 
 function TextareaTitle({
-  darkMode,
   value,
   register,
   placeholder,
   maxLength
 }: TextareaProps) {
+  const { darkMode } = useContext(TextareaContext);
   return (
     <Style.TextareaTitle
       darkMode={darkMode}

--- a/src/components/Common/Textarea/TextareaTitle.tsx
+++ b/src/components/Common/Textarea/TextareaTitle.tsx
@@ -5,25 +5,39 @@ import * as Style from './index.style';
 
 function TextareaTitle<T extends FieldValues>({
   value,
+  className = ``,
   register,
+  formKey,
+  registerOptions,
   placeholder,
   maxLength,
-  formKey
+  width,
+  height,
+  readonly = false
 }: TextareaProps<T>) {
   const { darkMode } = useContext(TextareaContext);
   return (
     <Style.TextareaTitle
       darkMode={darkMode}
-      value={value}
+      readOnly={readonly}
+      defaultValue={value}
       placeholder={placeholder}
       maxLength={maxLength}
-      {...(register && {
-        ...register(formKey, {
-          required: '작성자명은 반드시 입력해야합니다.'
-        })
-      })}
+      width={width}
+      height={height}
+      {...(register &&
+        formKey && {
+          ...register(formKey, registerOptions)
+        })}
+      className={className}
     />
   );
 }
+
+// {...(register &&
+//   formKey && {
+//     ...register(formKey, {
+//       required: '작성자명은 반드시 입력해야합니다.'
+//     })
 
 export default TextareaTitle;

--- a/src/components/Common/Textarea/TextareaTitle.tsx
+++ b/src/components/Common/Textarea/TextareaTitle.tsx
@@ -1,13 +1,15 @@
 import { useContext } from 'react';
+import { FieldValues } from 'react-hook-form';
 import { TextareaContext, TextareaProps } from './index';
 import * as Style from './index.style';
 
-function TextareaTitle({
+function TextareaTitle<T extends FieldValues>({
   value,
   register,
   placeholder,
-  maxLength
-}: TextareaProps) {
+  maxLength,
+  formKey
+}: TextareaProps<T>) {
   const { darkMode } = useContext(TextareaContext);
   return (
     <Style.TextareaTitle
@@ -16,7 +18,7 @@ function TextareaTitle({
       placeholder={placeholder}
       maxLength={maxLength}
       {...(register && {
-        ...register('letterTitle', {
+        ...register(formKey, {
           required: '작성자명은 반드시 입력해야합니다.'
         })
       })}

--- a/src/components/Common/Textarea/TextareaUnderLine.tsx
+++ b/src/components/Common/Textarea/TextareaUnderLine.tsx
@@ -1,0 +1,7 @@
+import * as Style from './index.style';
+
+function TextareaUnderLine() {
+  return <Style.TextareaUnderLine />;
+}
+
+export default TextareaUnderLine;

--- a/src/components/Common/Textarea/index.style.tsx
+++ b/src/components/Common/Textarea/index.style.tsx
@@ -1,0 +1,56 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const TextArea = css`
+  background-color: transparent;
+  border-color: transparent;
+  outline: none;
+  resize: none;
+  box-sizing: border-box;
+`;
+
+export const TextareaContainer = styled.div<{ darkMode: boolean }>`
+  background-color: ${(props) =>
+    props.darkMode ? props.theme.palette.sub : props.theme.palette.dark};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 20.3125rem;
+  border-radius: 20px;
+  margin-top: 1.625rem;
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+`;
+
+export const TextareaTitle = styled.textarea<{ darkMode: boolean }>`
+  ${TextArea};
+  color: ${(props) =>
+    props.darkMode
+      ? props.theme.palette.light_font
+      : props.theme.palette.dark_font};
+  flex-grow: 0;
+  width: 95%;
+  height: 40px;
+  font-size: 1rem;
+  font-weight: 500;
+  padding: 1rem 3rem 0 0.9rem;
+`;
+
+export const TextareaContent = styled.textarea<{ darkMode: boolean }>`
+  ${TextArea};
+  color: ${(props) =>
+    props.darkMode
+      ? props.theme.palette.light_font
+      : props.theme.palette.dark_font};
+  flex-grow: 1;
+  font-size: 0.7rem;
+  width: 95%;
+  margin: 0.6rem 0;
+  padding: 0 1rem;
+`;
+
+export const TextareaUnderLine = styled.div`
+  width: 90%;
+  height: 1px;
+  background-color: #aca3a3;
+`;

--- a/src/components/Common/Textarea/index.style.tsx
+++ b/src/components/Common/Textarea/index.style.tsx
@@ -9,14 +9,20 @@ const TextArea = css`
   box-sizing: border-box;
 `;
 
-export const TextareaContainer = styled.div<{ darkMode: boolean }>`
+// width: 100%;
+// height: 20.3125rem;
+export const TextareaContainer = styled.div<{
+  darkMode: boolean;
+  width?: string;
+  height?: string;
+}>`
   background-color: ${(props) =>
     props.darkMode ? props.theme.palette.sub : props.theme.palette.dark};
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
-  height: 20.3125rem;
+  width: ${(props) => `${props.width};`}
+  height: ${(props) => `${props.height};`}
   border-radius: 20px;
   margin-top: 1.625rem;
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);

--- a/src/components/Common/Textarea/index.style.tsx
+++ b/src/components/Common/Textarea/index.style.tsx
@@ -9,40 +9,49 @@ const TextArea = css`
   box-sizing: border-box;
 `;
 
-// width: 100%;
-// height: 20.3125rem;
 export const TextareaContainer = styled.div<{
   darkMode: boolean;
-  width?: string;
-  height?: string;
+  width: string;
+  height: string;
 }>`
+  position: relative;
   background-color: ${(props) =>
     props.darkMode ? props.theme.palette.sub : props.theme.palette.dark};
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: ${(props) => `${props.width};`}
-  height: ${(props) => `${props.height};`}
+  width: ${({ width }) => `${width};`}
+  height: ${({ height }) => `${height};`}
   border-radius: 20px;
   margin-top: 1.625rem;
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  ${({ className }) => `${className}`}
 `;
 
-export const TextareaTitle = styled.textarea<{ darkMode: boolean }>`
+export const TextareaTitle = styled.textarea<{
+  darkMode: boolean;
+  width: string;
+  height: string;
+}>`
   ${TextArea};
   color: ${(props) =>
     props.darkMode
       ? props.theme.palette.light_font
       : props.theme.palette.dark_font};
   flex-grow: 0;
-  width: 95%;
-  height: 40px;
+  width: ${({ width }) => `${width};`}
+  height: ${({ height }) => `${height};`}
   font-size: 1rem;
   font-weight: 500;
   padding: 1rem 3rem 0 0.9rem;
+  ${({ className }) => `${className}`}
 `;
 
-export const TextareaContent = styled.textarea<{ darkMode: boolean }>`
+export const TextareaContent = styled.textarea<{
+  darkMode: boolean;
+  width: string;
+  height: string;
+}>`
   ${TextArea};
   color: ${(props) =>
     props.darkMode
@@ -50,13 +59,16 @@ export const TextareaContent = styled.textarea<{ darkMode: boolean }>`
       : props.theme.palette.dark_font};
   flex-grow: 1;
   font-size: 0.7rem;
-  width: 95%;
+  width: ${({ width }) => `${width};`}
+  height: ${({ height }) => (height ? `${height};` : 'auto;')}
   margin: 0.6rem 0;
   padding: 0 1rem;
+  ${({ className }) => `${className}`}
 `;
 
 export const TextareaUnderLine = styled.div`
   width: 90%;
   height: 1px;
   background-color: #aca3a3;
+  ${({ className }) => `${className}`}
 `;

--- a/src/components/Common/Textarea/index.tsx
+++ b/src/components/Common/Textarea/index.tsx
@@ -1,0 +1,47 @@
+import { ReactNode, createContext } from 'react';
+import { UseFormRegister } from 'react-hook-form';
+import { useAtomValue } from 'jotai';
+import { darkAtom } from '@/store/theme';
+import TextareaContent from './TextareaContent';
+import TextareaTitle from './TextareaTitle';
+import TextareaUnderLine from './TextareaUnderLine';
+import * as Style from './index.style';
+
+const TextareaContext = createContext({
+  darkMode: false
+});
+
+interface TextareaContainerProps {
+  children: ReactNode;
+}
+
+export interface useFormProps {
+  letterTitle: string;
+  letterContent: string;
+}
+
+export interface TextareaProps {
+  darkMode: boolean;
+  value?: undefined | string;
+  register?: UseFormRegister<useFormProps>;
+  placeholder: string;
+  maxLength?: number;
+}
+
+function Textarea({ children }: TextareaContainerProps) {
+  const darkMode = useAtomValue(darkAtom);
+
+  return (
+    <TextareaContext.Provider value={{ darkMode }}>
+      <Style.TextareaContainer darkMode={darkMode}>
+        {children}
+      </Style.TextareaContainer>
+    </TextareaContext.Provider>
+  );
+}
+
+Textarea.TextareaTitle = TextareaTitle;
+Textarea.TextareaContent = TextareaContent;
+Textarea.TextareaUnderLine = TextareaUnderLine;
+
+export default Textarea;

--- a/src/components/Common/Textarea/index.tsx
+++ b/src/components/Common/Textarea/index.tsx
@@ -7,7 +7,7 @@ import TextareaTitle from './TextareaTitle';
 import TextareaUnderLine from './TextareaUnderLine';
 import * as Style from './index.style';
 
-const TextareaContext = createContext({
+export const TextareaContext = createContext({
   darkMode: false
 });
 
@@ -21,7 +21,6 @@ export interface useFormProps {
 }
 
 export interface TextareaProps {
-  darkMode: boolean;
   value?: undefined | string;
   register?: UseFormRegister<useFormProps>;
   placeholder: string;

--- a/src/components/Common/Textarea/index.tsx
+++ b/src/components/Common/Textarea/index.tsx
@@ -13,22 +13,27 @@ export const TextareaContext = createContext({
 
 interface TextareaContainerProps {
   children: ReactNode;
+  width?: string;
+  height?: string;
 }
 
 export interface TextareaProps<T extends FieldValues> {
-  value?: undefined | string;
+  value?: string;
   register?: UseFormRegister<T>;
   placeholder: string;
   maxLength?: number;
   formKey: Path<T>;
 }
 
-function Textarea({ children }: TextareaContainerProps) {
+function Textarea({ children, width, height }: TextareaContainerProps) {
   const darkMode = useAtomValue(darkAtom);
 
   return (
     <TextareaContext.Provider value={{ darkMode }}>
-      <Style.TextareaContainer darkMode={darkMode}>
+      <Style.TextareaContainer
+        darkMode={darkMode}
+        width={width}
+        height={height}>
         {children}
       </Style.TextareaContainer>
     </TextareaContext.Provider>

--- a/src/components/Common/Textarea/index.tsx
+++ b/src/components/Common/Textarea/index.tsx
@@ -1,7 +1,15 @@
 import { ReactNode, createContext } from 'react';
-import { FieldValues, Path, UseFormRegister } from 'react-hook-form';
+import {
+  FieldValues,
+  Path,
+  RegisterOptions,
+  UseFormRegister
+} from 'react-hook-form';
 import { useAtomValue } from 'jotai';
 import { darkAtom } from '@/store/theme';
+import CompleteButton from './Button/Complete';
+import DeleteButton from './Button/Delete';
+import EditButton from './Button/Edit';
 import TextareaContent from './TextareaContent';
 import TextareaTitle from './TextareaTitle';
 import TextareaUnderLine from './TextareaUnderLine';
@@ -13,19 +21,30 @@ export const TextareaContext = createContext({
 
 interface TextareaContainerProps {
   children: ReactNode;
-  width?: string;
-  height?: string;
+  width: string;
+  height: string;
+  className?: string;
 }
 
 export interface TextareaProps<T extends FieldValues> {
   value?: string;
   register?: UseFormRegister<T>;
-  placeholder: string;
+  registerOptions?: RegisterOptions;
+  placeholder?: string;
   maxLength?: number;
-  formKey: Path<T>;
+  formKey?: Path<T>;
+  readonly?: boolean;
+  width: string;
+  height: string;
+  className?: string;
 }
 
-function Textarea({ children, width, height }: TextareaContainerProps) {
+function Textarea({
+  children,
+  width,
+  height,
+  className = ``
+}: TextareaContainerProps) {
   const darkMode = useAtomValue(darkAtom);
 
   return (
@@ -33,7 +52,8 @@ function Textarea({ children, width, height }: TextareaContainerProps) {
       <Style.TextareaContainer
         darkMode={darkMode}
         width={width}
-        height={height}>
+        height={height}
+        className={className}>
         {children}
       </Style.TextareaContainer>
     </TextareaContext.Provider>
@@ -43,5 +63,8 @@ function Textarea({ children, width, height }: TextareaContainerProps) {
 Textarea.TextareaTitle = TextareaTitle;
 Textarea.TextareaContent = TextareaContent;
 Textarea.TextareaUnderLine = TextareaUnderLine;
+Textarea.CompleteButton = CompleteButton;
+Textarea.EditButton = EditButton;
+Textarea.DeleteButton = DeleteButton;
 
 export default Textarea;

--- a/src/components/Common/Textarea/index.tsx
+++ b/src/components/Common/Textarea/index.tsx
@@ -15,14 +15,9 @@ interface TextareaContainerProps {
   children: ReactNode;
 }
 
-export interface useFormProps {
-  letterTitle: string;
-  letterContent: string;
-}
-
 export interface TextareaProps {
   value?: undefined | string;
-  register?: UseFormRegister<useFormProps>;
+  register?: UseFormRegister<Record<string, string>>;
   placeholder: string;
   maxLength?: number;
 }

--- a/src/components/Common/Textarea/index.tsx
+++ b/src/components/Common/Textarea/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, createContext } from 'react';
-import { UseFormRegister } from 'react-hook-form';
+import { FieldValues, Path, UseFormRegister } from 'react-hook-form';
 import { useAtomValue } from 'jotai';
 import { darkAtom } from '@/store/theme';
 import TextareaContent from './TextareaContent';
@@ -15,11 +15,12 @@ interface TextareaContainerProps {
   children: ReactNode;
 }
 
-export interface TextareaProps {
+export interface TextareaProps<T extends FieldValues> {
   value?: undefined | string;
-  register?: UseFormRegister<Record<string, string>>;
+  register?: UseFormRegister<T>;
   placeholder: string;
   maxLength?: number;
+  formKey: Path<T>;
 }
 
 function Textarea({ children }: TextareaContainerProps) {

--- a/src/components/Post/Letter/index.tsx
+++ b/src/components/Post/Letter/index.tsx
@@ -1,5 +1,5 @@
 import { UseFormRegister } from 'react-hook-form';
-import * as Style from './index.style';
+import Textarea from '@components/Common/Textarea';
 
 export interface useFormProps {
   letterTitle: string;
@@ -13,8 +13,8 @@ interface letterProps {
 
 function Letter({ darkMode, register, userName }: letterProps) {
   return (
-    <Style.LetterContainer darkMode={darkMode}>
-      <Style.LetterTitle
+    <Textarea>
+      <Textarea.TextareaTitle
         darkMode={darkMode}
         value={
           userName ? (userName === '익명' ? undefined : userName) : undefined
@@ -27,19 +27,15 @@ function Letter({ darkMode, register, userName }: letterProps) {
             : '작성자명을 입력해주세요(최대 15자)'
         }
         maxLength={15}
-        {...register('letterTitle', {
-          required: '작성자명은 반드시 입력해야합니다.'
-        })}
+        register={register}
       />
-      <Style.TitleUnderLine />
-      <Style.LetterContent
+      <Textarea.TextareaUnderLine />
+      <Textarea.TextareaContent
         darkMode={darkMode}
-        placeholder="내용을 입력하세요"
-        {...register('letterComment', {
-          required: '편지 내용은 반드시 입력해야합니다.'
-        })}
+        placeholder={'내용을 입력하세요'}
+        register={register}
       />
-    </Style.LetterContainer>
+    </Textarea>
   );
 }
 

--- a/src/components/Post/Letter/index.tsx
+++ b/src/components/Post/Letter/index.tsx
@@ -3,19 +3,18 @@ import Textarea from '@components/Common/Textarea';
 
 export interface useFormProps {
   letterTitle: string;
-  letterComment: string;
+  letterContent: string;
 }
 interface letterProps {
-  darkMode: boolean;
   register: UseFormRegister<useFormProps>;
   userName: string;
 }
-
-function Letter({ darkMode, register, userName }: letterProps) {
+function Letter({ register, userName }: letterProps) {
   return (
-    <Textarea>
+    <Textarea
+      width={'100%'}
+      height={'20.3125rem'}>
       <Textarea.TextareaTitle
-        darkMode={darkMode}
         value={
           userName ? (userName === '익명' ? undefined : userName) : undefined
         }
@@ -23,17 +22,28 @@ function Letter({ darkMode, register, userName }: letterProps) {
           userName
             ? userName === '익명'
               ? '작성자명을 입력해주세요(최대 15자)'
-              : ''
+              : userName
             : '작성자명을 입력해주세요(최대 15자)'
         }
         maxLength={15}
         register={register}
+        formKey={'letterTitle'}
+        registerOptions={{
+          required: '작성자명은 반드시 입력해야합니다.'
+        }}
+        width={'95%'}
+        height={'40px'}
       />
       <Textarea.TextareaUnderLine />
       <Textarea.TextareaContent
-        darkMode={darkMode}
         placeholder={'내용을 입력하세요'}
         register={register}
+        formKey={'letterContent'}
+        registerOptions={{
+          required: '내용을 반드시 입력해야합니다.'
+        }}
+        width={'95%'}
+        height={''}
       />
     </Textarea>
   );

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -9,9 +9,9 @@ import { usePostCreateMutation } from '@/hooks/api/usePostCreateMutation';
 import { channelNameAtom, tokenAtom } from '@/store/auth';
 import { darkAtom } from '@/store/theme';
 import Button from '../Common/Button';
+import Textarea from '../Common/Textarea';
 import Footer from './Footer';
 import Header from './Header';
-import Letter from './Letter';
 import Warning from './Warning';
 import * as Style from './index.style';
 
@@ -23,7 +23,7 @@ const toastStyle = {
 
 export interface useFormProps {
   letterTitle: string;
-  letterComment: string;
+  letterContent: string;
 }
 
 export interface channelInfo {
@@ -56,7 +56,7 @@ function Post() {
     mode: 'onSubmit',
     defaultValues: {
       letterTitle: userName ? userName : '',
-      letterComment: ''
+      letterContent: ''
     }
   });
 
@@ -65,7 +65,7 @@ function Post() {
     if (channelId)
       mutationPostCreate({
         title: submitData.letterTitle,
-        content: submitData.letterComment,
+        content: submitData.letterContent,
         image: null,
         channelId,
         color: state.color
@@ -75,8 +75,8 @@ function Post() {
   useEffect(() => {
     /** react-hook-form validation */
     if (isSubmitting) {
-      errors.letterComment
-        ? toast.error(errors.letterComment.message as string)
+      errors.letterContent
+        ? toast.error(errors.letterContent.message as string)
         : null;
       errors.letterTitle
         ? toast.error(errors.letterTitle.message as string)
@@ -131,11 +131,33 @@ function Post() {
         ))}
       <Style.PostContainer>
         <Header channelName={state.channelName} />
-        <Letter
-          darkMode={darkMode}
-          userName={userName}
-          register={register}
-        />
+        <Textarea>
+          <Textarea.TextareaTitle
+            darkMode={darkMode}
+            value={
+              userName
+                ? userName === '익명'
+                  ? undefined
+                  : userName
+                : undefined
+            }
+            placeholder={
+              userName
+                ? userName === '익명'
+                  ? '작성자명을 입력해주세요(최대 15자)'
+                  : userName
+                : '작성자명을 입력해주세요(최대 15자)'
+            }
+            maxLength={15}
+            register={register}
+          />
+          <Textarea.TextareaUnderLine />
+          <Textarea.TextareaContent
+            darkMode={darkMode}
+            placeholder={'내용을 입력하세요'}
+            register={register}
+          />
+        </Textarea>
         <Warning allowRangeData={allowRangeData} />
         <Style.Form onSubmit={handleSubmit(onPostSubmit)}>
           <Footer />

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -133,7 +133,6 @@ function Post() {
         <Header channelName={state.channelName} />
         <Textarea>
           <Textarea.TextareaTitle
-            darkMode={darkMode}
             value={
               userName
                 ? userName === '익명'
@@ -153,7 +152,6 @@ function Post() {
           />
           <Textarea.TextareaUnderLine />
           <Textarea.TextareaContent
-            darkMode={darkMode}
             placeholder={'내용을 입력하세요'}
             register={register}
           />

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -40,7 +40,6 @@ export interface channelInfo {
 function Post() {
   const userName = useAtomValue(channelNameAtom);
   const JWTtoken = useAtomValue(tokenAtom);
-  const darkMode = useAtomValue(darkAtom);
 
   const { channelId } = useParams();
   const { state } = useLocation();

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -21,9 +21,11 @@ const toastStyle = {
   marginTop: '0.5rem'
 };
 
+const LETTER_TITLE = 'letterTitle';
+const LETTER_CONTENT = 'letterContent';
 export interface useFormProps {
-  letterTitle: string;
-  letterContent: string;
+  [LETTER_TITLE]: string;
+  [LETTER_CONTENT]: string;
 }
 
 export interface channelInfo {
@@ -62,6 +64,7 @@ function Post() {
 
   /** 포스트 작성 시 서버로 전송 */
   const onPostSubmit = (submitData: useFormProps) => {
+    console.log(submitData);
     if (channelId)
       mutationPostCreate({
         title: submitData.letterTitle,
@@ -149,11 +152,13 @@ function Post() {
             }
             maxLength={15}
             register={register}
+            formKey={LETTER_TITLE}
           />
           <Textarea.TextareaUnderLine />
           <Textarea.TextareaContent
             placeholder={'내용을 입력하세요'}
             register={register}
+            formKey={LETTER_CONTENT}
           />
         </Textarea>
         <Warning allowRangeData={allowRangeData} />

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -7,7 +7,6 @@ import Modal from '@components/Common/Modal';
 import { useAtomValue } from 'jotai';
 import { usePostCreateMutation } from '@/hooks/api/usePostCreateMutation';
 import { channelNameAtom, tokenAtom } from '@/store/auth';
-import { darkAtom } from '@/store/theme';
 import Button from '../Common/Button';
 import Textarea from '../Common/Textarea';
 import Footer from './Footer';
@@ -133,7 +132,9 @@ function Post() {
         ))}
       <Style.PostContainer>
         <Header channelName={state.channelName} />
-        <Textarea>
+        <Textarea
+          width={'100%'}
+          height={'20.3125rem'}>
           <Textarea.TextareaTitle
             value={
               userName

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -8,9 +8,9 @@ import { useAtomValue } from 'jotai';
 import { usePostCreateMutation } from '@/hooks/api/usePostCreateMutation';
 import { channelNameAtom, tokenAtom } from '@/store/auth';
 import Button from '../Common/Button';
-import Textarea from '../Common/Textarea';
 import Footer from './Footer';
 import Header from './Header';
+import Letter from './Letter';
 import Warning from './Warning';
 import * as Style from './index.style';
 
@@ -20,11 +20,9 @@ const toastStyle = {
   marginTop: '0.5rem'
 };
 
-const LETTER_TITLE = 'letterTitle';
-const LETTER_CONTENT = 'letterContent';
 export interface useFormProps {
-  [LETTER_TITLE]: string;
-  [LETTER_CONTENT]: string;
+  letterTitle: string;
+  letterContent: string;
 }
 
 export interface channelInfo {
@@ -132,35 +130,10 @@ function Post() {
         ))}
       <Style.PostContainer>
         <Header channelName={state.channelName} />
-        <Textarea
-          width={'100%'}
-          height={'20.3125rem'}>
-          <Textarea.TextareaTitle
-            value={
-              userName
-                ? userName === '익명'
-                  ? undefined
-                  : userName
-                : undefined
-            }
-            placeholder={
-              userName
-                ? userName === '익명'
-                  ? '작성자명을 입력해주세요(최대 15자)'
-                  : userName
-                : '작성자명을 입력해주세요(최대 15자)'
-            }
-            maxLength={15}
-            register={register}
-            formKey={LETTER_TITLE}
-          />
-          <Textarea.TextareaUnderLine />
-          <Textarea.TextareaContent
-            placeholder={'내용을 입력하세요'}
-            register={register}
-            formKey={LETTER_CONTENT}
-          />
-        </Textarea>
+        <Letter
+          register={register}
+          userName={userName}
+        />
         <Warning allowRangeData={allowRangeData} />
         <Style.Form onSubmit={handleSubmit(onPostSubmit)}>
           <Footer />

--- a/src/components/PostComment/Comment/index.tsx
+++ b/src/components/PostComment/Comment/index.tsx
@@ -1,5 +1,5 @@
 import { UseFormRegister } from 'react-hook-form';
-import * as Style from './index.style';
+import Textarea from '@/components/Common/Textarea';
 
 interface useFormProps {
   commentTitle: string;
@@ -9,36 +9,37 @@ interface useFormProps {
 interface CommentProps {
   register: UseFormRegister<useFormProps>;
   userName: string;
-  darkMode: boolean;
 }
 
-function Comment({ darkMode, register, userName }: CommentProps) {
+function Comment({ register, userName }: CommentProps) {
   return (
-    <>
-      <Style.CommentContainer darkMode={darkMode}>
-        <Style.CommentTitleInput
-          darkMode={darkMode}
-          placeholder={userName ? '' : '작성자명을 입력해주세요'}
-          value={userName ? userName : undefined}
-          {...(userName === ''
-            ? {
-                ...register('commentTitle', {
-                  required: '작성자명은 반드시 입력하셔야합니다.'
-                })
-              }
-            : false)}
-        />
-
-        <Style.CommentTitleUnderLine />
-        <Style.CommentContent
-          darkMode={darkMode}
-          placeholder="댓글을 입력하세요"
-          {...register('commentContent', {
-            required: '댓글 내용은 반드시 입력하셔야합니다.'
-          })}
-        />
-      </Style.CommentContainer>
-    </>
+    <Textarea
+      width={'100%'}
+      height={'8.1875rem'}>
+      <Textarea.TextareaTitle
+        readonly={true}
+        value={userName}
+        maxLength={15}
+        register={register}
+        formKey={'commentTitle'}
+        registerOptions={{
+          required: '작성자명은 반드시 입력해야합니다.'
+        }}
+        width={'95%'}
+        height={'40px'}
+      />
+      <Textarea.TextareaUnderLine />
+      <Textarea.TextareaContent
+        placeholder={'내용을 입력하세요'}
+        register={register}
+        formKey={'commentContent'}
+        registerOptions={{
+          required: '내용을 반드시 입력해야합니다.'
+        }}
+        width={'95%'}
+        height={''}
+      />
+    </Textarea>
   );
 }
 

--- a/src/components/PostComment/Footer/index.style.tsx
+++ b/src/components/PostComment/Footer/index.style.tsx
@@ -6,4 +6,5 @@ export const FooterContainer = styled.div`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
+  margin-top: 1rem;
 `;

--- a/src/components/PostComment/PrePost/index.tsx
+++ b/src/components/PostComment/PrePost/index.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import toast, { Toaster } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
+import Textarea from '@/components/Common/Textarea';
 import { useCommentDeleteMutation } from '@/hooks/api/useCommentDeleteMutation';
 import { useCreateNotification } from '@/hooks/api/useCreateNotification';
 import { useLikeCreateMutation } from '@/hooks/api/useLikeCreateMutation';
@@ -10,9 +11,7 @@ import { useLikeDeleteMutation } from '@/hooks/api/useLikeDeleteMutation';
 import { usePostDeleteMutation } from '@/hooks/api/usePostDeleteMutation';
 import { usePostUpdateMutation } from '@/hooks/api/usePostUpdateMutation';
 import likeIcon from '@/assets/Like.svg';
-import completeIcon from '@/assets/complete.svg';
 import deleteIcon from '@/assets/delete.svg';
-import editIcon from '@/assets/edit.svg';
 import { idAtom } from '@/store/auth';
 import { Post } from '@/types/ResponseType';
 import * as Style from './index.style';
@@ -38,11 +37,11 @@ function PrePost({ userName, darkMode, postId, postDetail }: PrePostProps) {
   const userId = useAtomValue(idAtom);
 
   const { mutate: likeCreateMutate, data: likeCreateData } =
-    useLikeCreateMutation(postId); // 특정 포스트 좋아요 추가
-  const { mutationLikeDelete } = useLikeDeleteMutation(postId); // 특정 포스트 좋아요 제거
-  const { mutationPostDelete } = usePostDeleteMutation(); // 특정 포스트 제거
-  const { mutationPostUpdate } = usePostUpdateMutation(postId); // 특정 포스트 수정
-  const { mutationCommentDelete } = useCommentDeleteMutation(postId); // 특정 댓글 제거
+    useLikeCreateMutation(postId);
+  const { mutationLikeDelete } = useLikeDeleteMutation(postId);
+  const { mutationPostDelete } = usePostDeleteMutation();
+  const { mutationPostUpdate } = usePostUpdateMutation(postId);
+  const { mutationCommentDelete } = useCommentDeleteMutation(postId);
   const { mutate: notificationMutate } = useCreateNotification();
   const navigator = useNavigate();
 
@@ -57,7 +56,7 @@ function PrePost({ userName, darkMode, postId, postDetail }: PrePostProps) {
     }
   });
 
-  const [postState, setPostState] = useState(false); // 상단 포스트 편집 여부 상태
+  const [isEdit, setIsEdit] = useState(true);
 
   /** 포스트 좋아요 추가 함수 */
   const handleLikeCreateClick = async () => {
@@ -84,17 +83,16 @@ function PrePost({ userName, darkMode, postId, postDetail }: PrePostProps) {
     }
   };
 
-  /** 특정 포스트 수정 함수 */
-  const handlePostToggleClick = () => {
-    setPostState((state) => !state);
+  const handleEditToggleClick = () => {
+    setIsEdit((state) => !state);
   };
 
-  /** 특정 포스트 삭제 함수 */
   const handleDeletePostClick = () => {
     if (userName === '익명') {
       toast.error('익명 회원은 편지를 삭제 할 수 없습니다.');
       return;
     }
+
     const deleteCheck = confirm(
       '편지를 삭제 하시겠습니까? 편지를 삭제하시면 편지를 포함한 모든 댓글도 함께 삭제됩니다.'
     );
@@ -108,26 +106,24 @@ function PrePost({ userName, darkMode, postId, postDetail }: PrePostProps) {
     }
   };
 
-  /** 특정 댓글 삭제하는 함수 */
   const handleDeleteCommentClick = (e: React.MouseEvent<HTMLImageElement>) => {
     if (userName === '익명') {
       toast.error('익명 회원은 댓글을 삭제할 수 없습니다.');
       return;
     }
+
     const deleteCheck = confirm('댓글 삭제하시겠습니까?');
     if (deleteCheck) {
       const targetElement = e.target as HTMLElement;
       const commentId = targetElement.dataset.id;
 
-      if (commentId) {
+      commentId &&
         mutationCommentDelete({
           id: commentId
         });
-      }
     }
   };
 
-  /** 포스트 수정 내용 서버 전송 함수 */
   const onSubmit = (submitData: userFormProps) => {
     mutationPostUpdate({
       postId,
@@ -137,70 +133,57 @@ function PrePost({ userName, darkMode, postId, postDetail }: PrePostProps) {
       color: postDetail ? JSON.parse(postDetail.title).color : ''
     });
 
-    handlePostToggleClick();
+    handleEditToggleClick();
   };
 
   useEffect(() => {
-    likeCreateData &&
+    if (likeCreateData) {
       notificationMutate({
         notificationType: 'LIKE',
         notificationTypeId: likeCreateData._id,
         userId: postDetail.author._id,
         postId: postDetail._id
       });
-  }, [likeCreateData]);
+    }
 
-  useEffect(() => {
     if (isSubmitting) {
       errors.prePostContent
         ? toast.error(errors.prePostContent.message as string)
         : null;
     }
-  }, [isSubmitting]);
+  }, [likeCreateData, isSubmitting]);
 
   return (
     <>
       <Style.PrePostAndCommentContainer>
-        <Style.PrePostContainer darkMode={darkMode}>
-          <Style.PrePostInnerTitle darkMode={darkMode}>
-            {postDetail && JSON.parse(postDetail.title).title}
-          </Style.PrePostInnerTitle>
-          <Style.PrePostUnnerline />
-          {postState ? (
-            <Style.PrePostEditContent
-              darkMode={darkMode}
-              defaultValue={postDetail && JSON.parse(postDetail.title).content}
-              {...register('prePostContent', {
-                required: '편지 내용은 반드시 입력해야 합니다.'
-              })}
-            />
-          ) : (
-            <Style.PrePostContent darkMode={darkMode}>
-              {postDetail && JSON.parse(postDetail.title).content}
-            </Style.PrePostContent>
-          )}
-          {postState ? (
-            <Style.CompleteImg
-              src={completeIcon}
-              onClick={handleSubmit(onSubmit)}
-            />
-          ) : (
-            <Style.EditImg
-              src={editIcon}
-              onClick={() => {
-                if (userName === '익명') {
-                  toast.error('익명 회원은 편지를 수정 할 수 없습니다.');
-                  return;
-                }
-                handlePostToggleClick();
-              }}
-            />
-          )}
-          <Style.DeleteImg
-            src={deleteIcon}
-            onClick={handleDeletePostClick}
+        <Textarea
+          width={'100%'}
+          height={'13.3125rem'}>
+          <Textarea.TextareaTitle
+            readonly={true}
+            value={postDetail && JSON.parse(postDetail.title).title}
+            maxLength={15}
+            width={'95%'}
+            height={'40px'}
           />
-        </Style.PrePostContainer>
+          <Textarea.TextareaUnderLine />
+          <Textarea.TextareaContent
+            readonly={isEdit}
+            placeholder={'내용을 입력하세요'}
+            register={register}
+            formKey={'prePostContent'}
+            registerOptions={{
+              required: '내용을 반드시 입력해야합니다.'
+            }}
+            width={'95%'}
+            height={'3rem'}
+          />
+          {isEdit && <Textarea.EditButton onClick={handleEditToggleClick} />}
+          {!isEdit && (
+            <Textarea.CompleteButton onClick={handleSubmit(onSubmit)} />
+          )}
+          <Textarea.DeleteButton onClick={handleDeletePostClick} />
+        </Textarea>
         <Style.LikeCommentContainer>
           <Style.LikeLogoContainer onClick={handleLikeCreateClick}>
             <Style.LikeLogo src={likeIcon} />

--- a/src/components/PostComment/index.tsx
+++ b/src/components/PostComment/index.tsx
@@ -74,7 +74,10 @@ function PostComment() {
   }, [commentCreateData]);
 
   useEffect(() => {
-    if (isSubmitSuccessful) reset();
+    if (isSubmitSuccessful)
+      reset({
+        commentContent: ''
+      });
 
     /** react-hook-form validation */
     if (isSubmitting) {
@@ -100,7 +103,6 @@ function PostComment() {
           />
         )}
         <Comment
-          darkMode={darkMode}
           register={register}
           userName={userName}
         />


### PR DESCRIPTION
## **📌** 작업 내용
기존의 Post, Comment 페이지에서 각각 구현되어 사용되는 Textarea 컴포넌트를 합성 컴포넌트를 적용하여 공통 컴포넌트화 시켰습니다. 합성 컴포넌트의 특징을 사용하여 Post, Comment 페이지에서 편지 작성 및 댓글 작성은 비슷한 UI를 사용하지만, 이전 포스트를 수정하는 prePost 컴포넌트는 버튼 아이콘을 내포하기 있기에 다른 UI를 가진 prePost 컴포넌트에서도 Textarea 공통 컴포넌트를 사용할 수 있게 유연성을 확장하여 합성 컴포넌트 방식을 사용했습니다.
<p><p />

> 기존 구조와 개선 방식 도식화
<img width="894" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/91654577/a06d4ba4-52cf-4693-bf7f-a65496ccd2bd">
<p><p />

> Interface에 formKey, registorOptions를 추가하여 React-Hook-Form을 재사용할 수 있게 구현해주었습니다
<img width="415" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC5_jackpot_letter_Donguk/assets/91654577/a0ce2304-50d7-4f97-a57a-e76abe96fab5">
<p><p />

> Textarea 공통 컴포넌트 구조

📦Textarea
 ┣ 📂Button
 ┃ ┣ 📂Complete
 ┃ ┃ ┣ 📜index.style.tsx
 ┃ ┃ ┗ 📜index.tsx
 ┃ ┣ 📂Delete
 ┃ ┃ ┣ 📜index.style.tsx
 ┃ ┃ ┗ 📜index.tsx
 ┃ ┗ 📂Edit
 ┃ ┃ ┣ 📜index.style.tsx
 ┃ ┃ ┗ 📜index.tsx
 ┣ 📜TextareaContent.tsx
 ┣ 📜TextareaTitle.tsx
 ┣ 📜TextareaUnderLine.tsx
 ┣ 📜index.style.tsx
 ┗ 📜index.tsx



## 🚦 특이 사항
- 현재 다크모드 관련된 상태를 jotai로 관리하며 전역적으로 관리하고 있는데 현재 코드에서는 ContextAPI를 사용하여 Textarea 컴포넌트와 관련된 다른 컴포넌트들이 Context API내의 다크모드 상태를 모두 바라보게 구현하였음. 다크모드를 제외한 Textarea 관련된 데이터들이 Textarea 컴포넌트 안에서만 묶여서 응집도 있게 사용하기 위해 ContextAPI를 사용하였는데, 이 방향성이 옳은지는 의문이라 좀 더 학습 할 예정.